### PR TITLE
Control a HD44780 LCD display with an ESP32

### DIFF
--- a/provisioning/esp32/smart_desk/components/debug_utils/CMakeLists.txt
+++ b/provisioning/esp32/smart_desk/components/debug_utils/CMakeLists.txt
@@ -1,3 +1,3 @@
-idf_component_register(SRCS "board_info.c" "app_info.c"
+idf_component_register(SRCS "board_info.c" "app_info.c" "print_utils.c"
     INCLUDE_DIRS "."
     REQUIRES app_update spi_flash)

--- a/provisioning/esp32/smart_desk/components/debug_utils/print_utils.c
+++ b/provisioning/esp32/smart_desk/components/debug_utils/print_utils.c
@@ -1,0 +1,1 @@
+#include "print_utils.h"

--- a/provisioning/esp32/smart_desk/components/debug_utils/print_utils.h
+++ b/provisioning/esp32/smart_desk/components/debug_utils/print_utils.h
@@ -1,0 +1,17 @@
+#define BYTE_TO_BINARY_PATTERN "%c%c%c%c%c%c%c%c"
+#define BYTE_TO_BINARY(byte)       \
+    (byte & 0x80 ? '1' : '0'),     \
+        (byte & 0x40 ? '1' : '0'), \
+        (byte & 0x20 ? '1' : '0'), \
+        (byte & 0x10 ? '1' : '0'), \
+        (byte & 0x08 ? '1' : '0'), \
+        (byte & 0x04 ? '1' : '0'), \
+        (byte & 0x02 ? '1' : '0'), \
+        (byte & 0x01 ? '1' : '0')
+
+#define NIBBLE_TO_BINARY_PATTERN "%c%c%c%c"
+#define NIBBLE_TO_BINARY(nibble)     \
+    (nibble & 0x80 ? '1' : '0'),     \
+        (nibble & 0x40 ? '1' : '0'), \
+        (nibble & 0x20 ? '1' : '0'), \
+        (nibble & 0x10 ? '1' : '0')

--- a/provisioning/esp32/smart_desk/components/i2c_manager/CMakeLists.txt
+++ b/provisioning/esp32/smart_desk/components/i2c_manager/CMakeLists.txt
@@ -1,2 +1,3 @@
 idf_component_register(SRCS "hd_44780.c" "i2c_utils.c"
-    INCLUDE_DIRS ".")
+    INCLUDE_DIRS "."
+    REQUIRES debug_utils)

--- a/provisioning/esp32/smart_desk/components/i2c_manager/CMakeLists.txt
+++ b/provisioning/esp32/smart_desk/components/i2c_manager/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "hd_44780.c" "i2c_utils.c"
+    INCLUDE_DIRS ".")

--- a/provisioning/esp32/smart_desk/components/i2c_manager/hd_44780.c
+++ b/provisioning/esp32/smart_desk/components/i2c_manager/hd_44780.c
@@ -24,7 +24,7 @@ static uint8_t _Rw;                  // LCD expander word for R/W pin
 static uint8_t _Rs;                  // LCD expander word for Register Select pin
 static uint8_t _data_pins[4];        // LCD data lines
 
-void LCD_write_4_bits(uint8_t nibble, uint8_t reg)
+static void LCD_write_4_bits(uint8_t nibble, uint8_t reg)
 {
     ESP_LOGI(TAG, "Sending 4 bits to LCD: " BYTE_TO_BINARY_PATTERN, BYTE_TO_BINARY(nibble));
 
@@ -61,7 +61,7 @@ void LCD_write_4_bits(uint8_t nibble, uint8_t reg)
     ets_delay_us(500);
 }
 
-void send(uint8_t value, uint8_t mode, uint8_t reg)
+static void send(uint8_t value, uint8_t mode, uint8_t reg)
 {
     // No need to use the delay routines since the time taken to write takes
     // longer that what is needed both for toggling and enable pin an to execute
@@ -80,7 +80,7 @@ void send(uint8_t value, uint8_t mode, uint8_t reg)
     }
 }
 
-void setBacklight(uint8_t value)
+static void setBacklight(uint8_t value)
 {
     // Check if backlight is available
     // ----------------------------------------------------
@@ -186,7 +186,7 @@ void LCD_writeChar(char c)
     send(c, LCD_SEND_8_BITS, LCD_DATA_REGISTER);
 }
 
-void LCD_writeStr(char *str)
+void LCD_writeStr(const char *str)
 {
     ESP_LOGI(TAG, "Write string: %s", str);
     while (*str)
@@ -233,7 +233,7 @@ void LCD_turnDisplayOff(void)
 void LCD_turnDisplayOn(void)
 {
     ESP_LOGI(TAG, "Turning the Display ON...");
-    send(LCD_DISPLAY_ON_OFF | LCD_DISPLAY_ON_OFF_DISPLAY_ON | LCD_DISPLAY_ON_OFF_CURSOR_ON | LCD_DISPLAY_ON_OFF_BLINK_ON, LCD_SEND_8_BITS, LCD_INSTRUCTION_REGISTER);
+    send(LCD_DISPLAY_ON_OFF | LCD_DISPLAY_ON_OFF_DISPLAY_ON | LCD_DISPLAY_ON_OFF_CURSOR_OFF | LCD_DISPLAY_ON_OFF_BLINK_OFF, LCD_SEND_8_BITS, LCD_INSTRUCTION_REGISTER);
     ets_delay_us(80);
 
     LCD_switchBacklightOn();
@@ -242,7 +242,8 @@ void LCD_turnDisplayOn(void)
 void LCD_Demo()
 {
     ESP_LOGI(TAG, "Starting the LCD demo...");
-
+    LCD_clearScreen();
+    LCD_home();
     LCD_turnDisplayOn();
     LCD_switchBacklightOn();
 
@@ -253,11 +254,21 @@ void LCD_Demo()
 
         LCD_home();
         LCD_clearScreen();
+
+        LCD_switchBacklightOn();
         vTaskDelay(1000 / portTICK_RATE_MS);
+        LCD_switchBacklightOff();
+        vTaskDelay(1000 / portTICK_RATE_MS);
+        LCD_switchBacklightOn();
+        vTaskDelay(1000 / portTICK_RATE_MS);
+        LCD_switchBacklightOff();
+        vTaskDelay(1000 / portTICK_RATE_MS);
+        LCD_switchBacklightOn();
+
         LCD_writeStr("----- 20x4 LCD -----");
         vTaskDelay(1000 / portTICK_RATE_MS);
         LCD_setCursor(0, 1);
-        LCD_writeStr("LCD Library Demo");
+        LCD_writeStr("LCD Demo");
         LCD_setCursor(12, 3);
         LCD_writeStr("Time: ");
         for (int i = 10; i >= 0; i--)

--- a/provisioning/esp32/smart_desk/components/i2c_manager/hd_44780.c
+++ b/provisioning/esp32/smart_desk/components/i2c_manager/hd_44780.c
@@ -1,0 +1,212 @@
+#include <stdio.h>
+#include "sdkconfig.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "driver/i2c.h"
+#include "esp32/rom/ets_sys.h"
+
+#include "hd_44780.h"
+
+// LCD module defines
+#define LCD_LINEONE 0x00   // start of line 1
+#define LCD_LINETWO 0x40   // start of line 2
+#define LCD_LINETHREE 0x14 // start of line 3
+#define LCD_LINEFOUR 0x54  // start of line 4
+
+#define LCD_BACKLIGHT_ON 0x08
+#define LCD_BACKLIGHT_OFF 0x00
+#define LCD_ENABLE 0x04
+#define LCD_COMMAND 0x00
+#define LCD_WRITE 0x01
+
+#define LCD_SET_DDRAM_ADDR 0x80
+#define LCD_READ_BF 0x40
+
+// LCD commands
+#define LCD_CLEAR 0x01             // replace all characters with ASCII 'space'
+#define LCD_HOME 0x02              // return cursor to first position on first line
+#define LCD_ENTRY_MODE 0x06        // shift cursor from left to right on read/write
+#define LCD_DISPLAY_OFF 0x08       // turn display off
+#define LCD_DISPLAY_ON 0x0C        // display on, cursor off, don't blink character
+#define LCD_FUNCTION_RESET 0x30    // reset the LCD
+#define LCD_FUNCTION_SET_4BIT 0x28 // 4-bit data, 2-line display, 5 x 7 font
+#define LCD_SET_CURSOR 0x80        // set cursor position
+
+static const char *TAG = "hd_44780";
+
+static uint8_t LCD_addr;
+static uint8_t LCD_cols;
+static uint8_t LCD_rows;
+
+static void LCD_writeNibble(uint8_t nibble, uint8_t mode);
+static void LCD_writeByte(uint8_t data, uint8_t mode);
+static void LCD_pulseEnable(uint8_t nibble);
+
+void LCD_init(uint8_t addr, uint8_t cols, uint8_t rows)
+{
+    ESP_LOGI(TAG, "Initializing the LCD screen...");
+
+    LCD_addr = addr;
+    LCD_cols = cols;
+    LCD_rows = rows;
+    vTaskDelay(100 / portTICK_RATE_MS); // Initial 40 mSec delay
+
+    ESP_LOGI(TAG, "Resetting the LCD screen...");
+    LCD_writeNibble(LCD_FUNCTION_RESET, LCD_COMMAND);    // First part of reset sequence
+    vTaskDelay(10 / portTICK_RATE_MS);                   // 4.1 mS delay (min)
+    LCD_writeNibble(LCD_FUNCTION_RESET, LCD_COMMAND);    // second part of reset sequence
+    ets_delay_us(200);                                   // 100 uS delay (min)
+    LCD_writeNibble(LCD_FUNCTION_RESET, LCD_COMMAND);    // Third time's a charm
+    LCD_writeNibble(LCD_FUNCTION_SET_4BIT, LCD_COMMAND); // Activate 4-bit mode
+    ets_delay_us(80);                                    // 40 uS delay (min)
+
+    // --- Busy flag now available ---
+    // Function Set instruction
+    ESP_LOGI(TAG, "Set LCD mode...");
+    LCD_writeByte(LCD_FUNCTION_SET_4BIT, LCD_COMMAND); // Set mode, lines, and font
+    ets_delay_us(80);
+
+    // Clear Display instruction
+    LCD_writeByte(LCD_CLEAR, LCD_COMMAND); // clear display RAM
+    vTaskDelay(2 / portTICK_RATE_MS);      // Clearing memory takes a bit longer
+
+    // Entry Mode Set instruction
+    LCD_writeByte(LCD_ENTRY_MODE, LCD_COMMAND); // Set desired shift characteristics
+    ets_delay_us(80);
+
+    LCD_writeByte(LCD_DISPLAY_ON, LCD_COMMAND); // Ensure LCD is set to on
+}
+
+void LCD_setCursor(uint8_t col, uint8_t row)
+{
+    if (row > LCD_rows - 1)
+    {
+        ESP_LOGE(TAG, "Cannot write to row %d. Please select a row in the range (0, %d)", row, LCD_rows - 1);
+        row = LCD_rows - 1;
+    }
+    uint8_t row_offsets[] = {LCD_LINEONE, LCD_LINETWO, LCD_LINETHREE, LCD_LINEFOUR};
+    LCD_writeByte(LCD_SET_DDRAM_ADDR | (col + row_offsets[row]), LCD_COMMAND);
+}
+
+void LCD_writeChar(char c)
+{
+    LCD_writeByte(c, LCD_WRITE); // Write data to DDRAM
+}
+
+void LCD_writeStr(char *str)
+{
+    while (*str)
+    {
+        LCD_writeChar(*str++);
+    }
+}
+
+void LCD_home(void)
+{
+    LCD_writeByte(LCD_HOME, LCD_COMMAND);
+    vTaskDelay(2 / portTICK_RATE_MS); // This command takes a while to complete
+}
+
+void LCD_clearScreen(void)
+{
+    LCD_writeByte(LCD_CLEAR, LCD_COMMAND);
+    vTaskDelay(2 / portTICK_RATE_MS); // This command takes a while to complete
+}
+
+static void LCD_writeNibble(uint8_t nibble, uint8_t mode)
+{
+    uint8_t data = (nibble & 0xF0) | mode | LCD_BACKLIGHT_ON;
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    ESP_ERROR_CHECK(i2c_master_start(cmd));
+    ESP_ERROR_CHECK(i2c_master_write_byte(cmd, (LCD_addr << 1) | I2C_MASTER_WRITE, 1));
+    ESP_ERROR_CHECK(i2c_master_write_byte(cmd, data, 1));
+    ESP_ERROR_CHECK(i2c_master_stop(cmd));
+    ESP_ERROR_CHECK(i2c_master_cmd_begin(I2C_NUM_0, cmd, 1000 / portTICK_PERIOD_MS));
+    i2c_cmd_link_delete(cmd);
+
+    LCD_pulseEnable(data); // Clock data into LCD
+}
+
+static void LCD_writeByte(uint8_t data, uint8_t mode)
+{
+    LCD_writeNibble(data & 0xF0, mode);
+    LCD_writeNibble((data << 4) & 0xF0, mode);
+}
+
+static void LCD_pulseEnable(uint8_t data)
+{
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    ESP_ERROR_CHECK(i2c_master_start(cmd));
+    ESP_ERROR_CHECK(i2c_master_write_byte(cmd, (LCD_addr << 1) | I2C_MASTER_WRITE, 1));
+    ESP_ERROR_CHECK(i2c_master_write_byte(cmd, data | LCD_ENABLE, 1));
+    ESP_ERROR_CHECK(i2c_master_stop(cmd));
+    ESP_ERROR_CHECK(i2c_master_cmd_begin(I2C_NUM_0, cmd, 1000 / portTICK_PERIOD_MS));
+    i2c_cmd_link_delete(cmd);
+    ets_delay_us(1);
+
+    cmd = i2c_cmd_link_create();
+    ESP_ERROR_CHECK(i2c_master_start(cmd));
+    ESP_ERROR_CHECK(i2c_master_write_byte(cmd, (LCD_addr << 1) | I2C_MASTER_WRITE, 1));
+    ESP_ERROR_CHECK(i2c_master_write_byte(cmd, (data & ~LCD_ENABLE), 1));
+    ESP_ERROR_CHECK(i2c_master_stop(cmd));
+    ESP_ERROR_CHECK(i2c_master_cmd_begin(I2C_NUM_0, cmd, 1000 / portTICK_PERIOD_MS));
+    i2c_cmd_link_delete(cmd);
+    ets_delay_us(500);
+}
+
+void LCD_Demo()
+{
+    ESP_LOGI(TAG, "Quick 3 blinks of backlight...");
+    for (int i = 0; i < 3; i++)
+    {
+        ESP_LOGI(TAG, "Backlight on...");
+        LCD_writeByte(LCD_BACKLIGHT_ON, LCD_COMMAND);
+        vTaskDelay(250 / portTICK_RATE_MS);
+        ESP_LOGI(TAG, "Backlight off...");
+        LCD_writeByte(LCD_BACKLIGHT_OFF, LCD_COMMAND);
+        vTaskDelay(250 / portTICK_RATE_MS);
+    }
+    ESP_LOGI(TAG, "Turning backlight on...");
+    LCD_writeByte(LCD_BACKLIGHT_ON, LCD_COMMAND);
+
+    ESP_LOGI(TAG, "Showing the demo...");
+    char txtBuf[11];
+    while (true)
+    {
+        int row = 0, col = 0;
+        LCD_home();
+        LCD_clearScreen();
+        LCD_writeStr("----- 20x4 LCD -----");
+        LCD_setCursor(0, 1);
+        LCD_writeStr("LCD Library Demo");
+        LCD_setCursor(12, 3);
+        LCD_writeStr("Time: ");
+        for (int i = 10; i >= 0; i--)
+        {
+            LCD_setCursor(18, 3);
+            sprintf(txtBuf, "%02d", i);
+            printf(txtBuf);
+            LCD_writeStr(txtBuf);
+            vTaskDelay(1000 / portTICK_RATE_MS);
+        }
+
+        for (int i = 0; i < 80; i++)
+        {
+            LCD_clearScreen();
+            LCD_setCursor(col, row);
+            LCD_writeChar('*');
+
+            if (i >= 19)
+            {
+                row = (i + 1) / 20;
+            }
+            if (col++ >= 19)
+            {
+                col = 0;
+            }
+
+            vTaskDelay(50 / portTICK_RATE_MS);
+        }
+    }
+}

--- a/provisioning/esp32/smart_desk/components/i2c_manager/hd_44780.c
+++ b/provisioning/esp32/smart_desk/components/i2c_manager/hd_44780.c
@@ -8,30 +8,7 @@
 
 #include "hd_44780.h"
 
-// LCD module defines
-#define LCD_LINEONE 0x00   // start of line 1
-#define LCD_LINETWO 0x40   // start of line 2
-#define LCD_LINETHREE 0x14 // start of line 3
-#define LCD_LINEFOUR 0x54  // start of line 4
-
-#define LCD_BACKLIGHT_ON 0x08
-#define LCD_BACKLIGHT_OFF 0x00
-#define LCD_ENABLE 0x04
-#define LCD_COMMAND 0x00
-#define LCD_WRITE 0x01
-
-#define LCD_SET_DDRAM_ADDR 0x80
-#define LCD_READ_BF 0x40
-
-// LCD commands
-#define LCD_CLEAR 0x01             // replace all characters with ASCII 'space'
-#define LCD_HOME 0x02              // return cursor to first position on first line
-#define LCD_ENTRY_MODE 0x06        // shift cursor from left to right on read/write
-#define LCD_DISPLAY_OFF 0x08       // turn display off
-#define LCD_DISPLAY_ON 0x0C        // display on, cursor off, don't blink character
-#define LCD_FUNCTION_RESET 0x30    // reset the LCD
-#define LCD_FUNCTION_SET_4BIT 0x28 // 4-bit data, 2-line display, 5 x 7 font
-#define LCD_SET_CURSOR 0x80        // set cursor position
+#include "print_utils.h"
 
 static const char *TAG = "hd_44780";
 
@@ -39,9 +16,47 @@ static uint8_t LCD_addr;
 static uint8_t LCD_cols;
 static uint8_t LCD_rows;
 
-static void LCD_writeNibble(uint8_t nibble, uint8_t mode);
-static void LCD_writeByte(uint8_t data, uint8_t mode);
-static void LCD_pulseEnable(uint8_t nibble);
+void LCD_writeNibble(uint8_t nibble, uint8_t mode, uint8_t reg)
+{
+    uint8_t data = (nibble & 0xF0) | mode | LCD_BACKLIGHT_ON;
+    ESP_LOGI(TAG, "Writing nibble: " NIBBLE_TO_BINARY_PATTERN, NIBBLE_TO_BINARY(data));
+
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    ESP_ERROR_CHECK(i2c_master_start(cmd));
+    ESP_ERROR_CHECK(i2c_master_write_byte(cmd, (LCD_addr << 1) | I2C_MASTER_WRITE, 1));
+    ESP_ERROR_CHECK(i2c_master_write_byte(cmd, data, 1));
+    ESP_ERROR_CHECK(i2c_master_stop(cmd));
+    ESP_ERROR_CHECK(i2c_master_cmd_begin(I2C_NUM_0, cmd, 1000 / portTICK_PERIOD_MS));
+    i2c_cmd_link_delete(cmd);
+
+    // Clock data into LCD
+    // was LCD_pulseEnable(data)
+    cmd = i2c_cmd_link_create();
+    ESP_ERROR_CHECK(i2c_master_start(cmd));
+    ESP_ERROR_CHECK(i2c_master_write_byte(cmd, (LCD_addr << 1) | I2C_MASTER_WRITE, 1));
+    ESP_ERROR_CHECK(i2c_master_write_byte(cmd, data | LCD_ENABLE_ON, 1));
+    ESP_ERROR_CHECK(i2c_master_stop(cmd));
+    ESP_ERROR_CHECK(i2c_master_cmd_begin(I2C_NUM_0, cmd, 1000 / portTICK_PERIOD_MS));
+    i2c_cmd_link_delete(cmd);
+    ets_delay_us(1);
+
+    cmd = i2c_cmd_link_create();
+    ESP_ERROR_CHECK(i2c_master_start(cmd));
+    ESP_ERROR_CHECK(i2c_master_write_byte(cmd, (LCD_addr << 1) | I2C_MASTER_WRITE, 1));
+    ESP_ERROR_CHECK(i2c_master_write_byte(cmd, (data & ~LCD_ENABLE_ON), 1));
+    ESP_ERROR_CHECK(i2c_master_stop(cmd));
+    ESP_ERROR_CHECK(i2c_master_cmd_begin(I2C_NUM_0, cmd, 1000 / portTICK_PERIOD_MS));
+    i2c_cmd_link_delete(cmd);
+    ets_delay_us(500);
+}
+
+void LCD_writeByte(uint8_t data, uint8_t mode, uint8_t reg)
+{
+    ESP_LOGI(TAG, "Writing byte: " BYTE_TO_BINARY_PATTERN, BYTE_TO_BINARY(data));
+
+    LCD_writeNibble(data & 0xF0, mode, reg);
+    LCD_writeNibble((data << 4) & 0xF0, mode, reg);
+}
 
 void LCD_init(uint8_t addr, uint8_t cols, uint8_t rows)
 {
@@ -52,50 +67,50 @@ void LCD_init(uint8_t addr, uint8_t cols, uint8_t rows)
     LCD_rows = rows;
     vTaskDelay(100 / portTICK_RATE_MS); // Initial 40 mSec delay
 
-    ESP_LOGI(TAG, "Resetting the LCD screen...");
-    LCD_writeNibble(LCD_FUNCTION_RESET, LCD_COMMAND);    // First part of reset sequence
-    vTaskDelay(10 / portTICK_RATE_MS);                   // 4.1 mS delay (min)
-    LCD_writeNibble(LCD_FUNCTION_RESET, LCD_COMMAND);    // second part of reset sequence
-    ets_delay_us(200);                                   // 100 uS delay (min)
-    LCD_writeNibble(LCD_FUNCTION_RESET, LCD_COMMAND);    // Third time's a charm
-    LCD_writeNibble(LCD_FUNCTION_SET_4BIT, LCD_COMMAND); // Activate 4-bit mode
-    ets_delay_us(80);                                    // 40 uS delay (min)
+    ESP_LOGI(TAG, "Resetting the LCD controller...");
+    LCD_writeNibble(LCD_FUNCTION_RESET, LCD_WRITE_MODE, LCD_INSTRUCTION_REGISTER); // First part of reset sequence
+    vTaskDelay(10 / portTICK_RATE_MS);                                             // 4.1 mS delay (min)
+    LCD_writeNibble(LCD_FUNCTION_RESET, LCD_WRITE_MODE, LCD_INSTRUCTION_REGISTER); // second part of reset sequence
+    ets_delay_us(200);                                                             // 100 uS delay (min)
+    LCD_writeNibble(LCD_FUNCTION_RESET, LCD_WRITE_MODE, LCD_INSTRUCTION_REGISTER); // Third time's a charm
 
-    // --- Busy flag now available ---
-    // Function Set instruction
-    ESP_LOGI(TAG, "Set LCD mode...");
-    LCD_writeByte(LCD_FUNCTION_SET_4BIT, LCD_COMMAND); // Set mode, lines, and font
+    ESP_LOGI(TAG, "Setting LCD function...");
+    LCD_writeByte(LCD_FUNCTION_SET | LCD_FUNCTION_SET_4_BIT | LCD_FUNCTION_SET_2_LINES | LCD_FUNCTION_SET_5X8, LCD_WRITE_MODE, LCD_INSTRUCTION_REGISTER);
     ets_delay_us(80);
 
-    // Clear Display instruction
-    LCD_writeByte(LCD_CLEAR, LCD_COMMAND); // clear display RAM
-    vTaskDelay(2 / portTICK_RATE_MS);      // Clearing memory takes a bit longer
-
-    // Entry Mode Set instruction
-    LCD_writeByte(LCD_ENTRY_MODE, LCD_COMMAND); // Set desired shift characteristics
+    ESP_LOGI(TAG, "Turning the LCD ON...");
+    LCD_writeByte(LCD_DISPLAY_ON_OFF | LCD_DISPLAY_ON_OFF_DISPLAY_ON | LCD_DISPLAY_ON_OFF_CURSOR_OFF | LCD_DISPLAY_ON_OFF_BLINK_OFF, LCD_WRITE_MODE, LCD_INSTRUCTION_REGISTER);
     ets_delay_us(80);
 
-    LCD_writeByte(LCD_DISPLAY_ON, LCD_COMMAND); // Ensure LCD is set to on
+    LCD_clearScreen();
+
+    // shift cursor from left to right on read/write
+    ESP_LOGI(TAG, "Setting LCD entry mode...");
+    LCD_writeByte(LCD_ENTRY_MODE_SET | LCD_ENTRY_MODE_SET_INCREMENT_DDRAM_ADDRESS, LCD_WRITE_MODE, LCD_INSTRUCTION_REGISTER);
+    ets_delay_us(80);
 }
 
 void LCD_setCursor(uint8_t col, uint8_t row)
 {
+    ESP_LOGI(TAG, "Set cursor to col %d, row %d", col, row);
     if (row > LCD_rows - 1)
     {
         ESP_LOGE(TAG, "Cannot write to row %d. Please select a row in the range (0, %d)", row, LCD_rows - 1);
         row = LCD_rows - 1;
     }
     uint8_t row_offsets[] = {LCD_LINEONE, LCD_LINETWO, LCD_LINETHREE, LCD_LINEFOUR};
-    LCD_writeByte(LCD_SET_DDRAM_ADDR | (col + row_offsets[row]), LCD_COMMAND);
+    LCD_writeByte(LCD_SET_DDRAM_ADDRESS | (col + row_offsets[row]), LCD_WRITE_MODE, LCD_INSTRUCTION_REGISTER);
 }
 
 void LCD_writeChar(char c)
 {
-    LCD_writeByte(c, LCD_WRITE); // Write data to DDRAM
+    ESP_LOGI(TAG, "Write char: %c", c);
+    LCD_writeByte(c, LCD_WRITE_MODE, LCD_DATA_REGISTER);
 }
 
 void LCD_writeStr(char *str)
 {
+    ESP_LOGI(TAG, "Write string: %s", str);
     while (*str)
     {
         LCD_writeChar(*str++);
@@ -104,109 +119,57 @@ void LCD_writeStr(char *str)
 
 void LCD_home(void)
 {
-    LCD_writeByte(LCD_HOME, LCD_COMMAND);
+    ESP_LOGI(TAG, "Return the cursor home");
+    LCD_writeByte(LCD_RETURN_HOME, LCD_WRITE_MODE, LCD_INSTRUCTION_REGISTER);
     vTaskDelay(2 / portTICK_RATE_MS); // This command takes a while to complete
 }
 
 void LCD_clearScreen(void)
 {
-    LCD_writeByte(LCD_CLEAR, LCD_COMMAND);
+    ESP_LOGI(TAG, "Clearing the LCD...");
+    LCD_writeByte(LCD_CLEAR_DISPLAY, LCD_WRITE_MODE, LCD_INSTRUCTION_REGISTER);
     vTaskDelay(2 / portTICK_RATE_MS); // This command takes a while to complete
-}
-
-static void LCD_writeNibble(uint8_t nibble, uint8_t mode)
-{
-    uint8_t data = (nibble & 0xF0) | mode | LCD_BACKLIGHT_ON;
-    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-    ESP_ERROR_CHECK(i2c_master_start(cmd));
-    ESP_ERROR_CHECK(i2c_master_write_byte(cmd, (LCD_addr << 1) | I2C_MASTER_WRITE, 1));
-    ESP_ERROR_CHECK(i2c_master_write_byte(cmd, data, 1));
-    ESP_ERROR_CHECK(i2c_master_stop(cmd));
-    ESP_ERROR_CHECK(i2c_master_cmd_begin(I2C_NUM_0, cmd, 1000 / portTICK_PERIOD_MS));
-    i2c_cmd_link_delete(cmd);
-
-    LCD_pulseEnable(data); // Clock data into LCD
-}
-
-static void LCD_writeByte(uint8_t data, uint8_t mode)
-{
-    LCD_writeNibble(data & 0xF0, mode);
-    LCD_writeNibble((data << 4) & 0xF0, mode);
-}
-
-static void LCD_pulseEnable(uint8_t data)
-{
-    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-    ESP_ERROR_CHECK(i2c_master_start(cmd));
-    ESP_ERROR_CHECK(i2c_master_write_byte(cmd, (LCD_addr << 1) | I2C_MASTER_WRITE, 1));
-    ESP_ERROR_CHECK(i2c_master_write_byte(cmd, data | LCD_ENABLE, 1));
-    ESP_ERROR_CHECK(i2c_master_stop(cmd));
-    ESP_ERROR_CHECK(i2c_master_cmd_begin(I2C_NUM_0, cmd, 1000 / portTICK_PERIOD_MS));
-    i2c_cmd_link_delete(cmd);
-    ets_delay_us(1);
-
-    cmd = i2c_cmd_link_create();
-    ESP_ERROR_CHECK(i2c_master_start(cmd));
-    ESP_ERROR_CHECK(i2c_master_write_byte(cmd, (LCD_addr << 1) | I2C_MASTER_WRITE, 1));
-    ESP_ERROR_CHECK(i2c_master_write_byte(cmd, (data & ~LCD_ENABLE), 1));
-    ESP_ERROR_CHECK(i2c_master_stop(cmd));
-    ESP_ERROR_CHECK(i2c_master_cmd_begin(I2C_NUM_0, cmd, 1000 / portTICK_PERIOD_MS));
-    i2c_cmd_link_delete(cmd);
-    ets_delay_us(500);
 }
 
 void LCD_Demo()
 {
-    ESP_LOGI(TAG, "Quick 3 blinks of backlight...");
-    for (int i = 0; i < 3; i++)
-    {
-        ESP_LOGI(TAG, "Backlight on...");
-        LCD_writeByte(LCD_BACKLIGHT_ON, LCD_COMMAND);
-        vTaskDelay(250 / portTICK_RATE_MS);
-        ESP_LOGI(TAG, "Backlight off...");
-        LCD_writeByte(LCD_BACKLIGHT_OFF, LCD_COMMAND);
-        vTaskDelay(250 / portTICK_RATE_MS);
-    }
-    ESP_LOGI(TAG, "Turning backlight on...");
-    LCD_writeByte(LCD_BACKLIGHT_ON, LCD_COMMAND);
-
-    ESP_LOGI(TAG, "Showing the demo...");
+    ESP_LOGI(TAG, "Showing the LCD demo...");
     char txtBuf[11];
     while (true)
     {
         int row = 0, col = 0;
-        LCD_home();
-        LCD_clearScreen();
-        LCD_writeStr("----- 20x4 LCD -----");
-        LCD_setCursor(0, 1);
-        LCD_writeStr("LCD Library Demo");
-        LCD_setCursor(12, 3);
-        LCD_writeStr("Time: ");
-        for (int i = 10; i >= 0; i--)
-        {
-            LCD_setCursor(18, 3);
-            sprintf(txtBuf, "%02d", i);
-            printf(txtBuf);
-            LCD_writeStr(txtBuf);
-            vTaskDelay(1000 / portTICK_RATE_MS);
-        }
+        // LCD_home();
+        // LCD_clearScreen();
+        vTaskDelay(1000 / portTICK_RATE_MS);
+        // LCD_writeStr("----- 20x4 LCD -----");
+        // LCD_setCursor(0, 1);
+        // LCD_writeStr("LCD Library Demo");
+        // LCD_setCursor(12, 3);
+        // LCD_writeStr("Time: ");
+        // for (int i = 10; i >= 0; i--)
+        // {
+        //     LCD_setCursor(18, 3);
+        //     sprintf(txtBuf, "%02d", i);
+        //     LCD_writeStr(txtBuf);
+        //     vTaskDelay(1000 / portTICK_RATE_MS);
+        // }
 
-        for (int i = 0; i < 80; i++)
-        {
-            LCD_clearScreen();
-            LCD_setCursor(col, row);
-            LCD_writeChar('*');
+        // for (int i = 0; i < 80; i++)
+        // {
+        //     LCD_clearScreen();
+        //     LCD_setCursor(col, row);
+        //     LCD_writeChar('*');
 
-            if (i >= 19)
-            {
-                row = (i + 1) / 20;
-            }
-            if (col++ >= 19)
-            {
-                col = 0;
-            }
+        //     if (i >= 19)
+        //     {
+        //         row = (i + 1) / 20;
+        //     }
+        //     if (col++ >= 19)
+        //     {
+        //         col = 0;
+        //     }
 
-            vTaskDelay(50 / portTICK_RATE_MS);
-        }
+        //     vTaskDelay(50 / portTICK_RATE_MS);
+        // }
     }
 }

--- a/provisioning/esp32/smart_desk/components/i2c_manager/hd_44780.h
+++ b/provisioning/esp32/smart_desk/components/i2c_manager/hd_44780.h
@@ -1,3 +1,68 @@
+// LCD display positions
+#define LCD_LINEONE 0x00   // Start of line 1
+#define LCD_LINETWO 0x40   // Start of line 2
+#define LCD_LINETHREE 0x14 // Start of line 3
+#define LCD_LINEFOUR 0x54  // Start of line 4
+
+// Pin mappings
+// P0 -> RS
+// P1 -> RW
+// P2 -> E
+// P3 -> Backlight (b) <- not sure about this
+// P4 -> D4
+// P5 -> D5
+// P6 -> D6
+// P7 -> D7
+
+// A0 backlight
+
+// Register select (data or instruction, RS bit)
+#define LCD_INSTRUCTION_REGISTER 0x00 // Instruction register
+#define LCD_DATA_REGISTER 0x01        // Data register - binary: 1
+
+// Command mode (read or write, R/W bit)
+#define LCD_WRITE_MODE 0x00 // Write data to the LCD display (I2C master -> I2C slave)
+#define LCD_READ_MODE 0x02  // Read data from the LCD display (I2C slave -> I2C master) - binary: 10
+
+// Enable bit
+#define LCD_ENABLE_ON 0x04 // Enable bit ON - binary: 100
+
+// Backlight bit
+#define LCD_BACKLIGHT_ON 0x08 // Enable LCD backlight - binary: 1000
+
+// LCD commands
+#define LCD_CLEAR_DISPLAY 0x01           // Replace all characters with ASCII SP (space, code 32, 0x20) - binary: 1
+#define LCD_RETURN_HOME 0x02             // Return cursor to first position on first line  - binary: 10
+#define LCD_ENTRY_MODE_SET 0x04          // Set the direction of the cursor movement and display shift - binary: 100
+#define LCD_DISPLAY_ON_OFF 0x08          // Turn on or off the display, show or hide the cursor, turn on or off cursor blinking - binary: 1000
+#define LCD_CURSOR_OR_DISPLAY_SHIFT 0x10 // Shift cursor or display position (useful to search or to correct data)
+#define LCD_FUNCTION_SET 0x20            // Set 8-bit or 4-bit command mode, set 1-line or 2-line display mode, set 5x8 or 5x11 font mode - binary: 100000
+#define LCD_FUNCTION_RESET 0x30          // Reset the LCD - binary: 110000
+#define LCD_SET_CGRAM_ADDRESS 0x40       // Set CGRAM address
+#define LCD_SET_DDRAM_ADDRESS 0x80       // Set DDRAM address (cursor position) - binary: 10000000
+
+// LCD command parameters
+#define LCD_ENTRY_MODE_SET_INCREMENT_DDRAM_ADDRESS 0x02           // Cursor moves to right and DDRAM address is increased by 1
+#define LCD_ENTRY_MODE_SET_DECREMENT_DDRAM_ADDRESS 0x00           // Cursor moves to left and DDRAM address is decreased by 1
+#define LCD_ENTRY_MODE_SET_SHIFT_DISPLAY 0x01                     // When reading from DDRAM, or reading from or writing to CGRAM, shift the entire display according to increment or decrement
+#define LCD_ENTRY_MODE_SET_NO_SHIFT_DISPLAY 0x00                  // When reading from DDRAM, or reading from or writing to CGRAM, don't shift the entire display according to increment or decrement
+#define LCD_DISPLAY_ON_OFF_DISPLAY_ON 0x04                        // Turn the entire display on - binary: 100
+#define LCD_DISPLAY_ON_OFF_DISPLAY_OFF 0x00                       // Turn the entire display off, but data remains in DDRAM
+#define LCD_DISPLAY_ON_OFF_CURSOR_ON 0x02                         // Show the cursor - binary: 10
+#define LCD_DISPLAY_ON_OFF_CURSOR_OFF 0x00                        // Hide the cursor, but the cursor position register preserves data
+#define LCD_DISPLAY_ON_OFF_BLINK_ON 0x02                          // Enable cursor blinking
+#define LCD_DISPLAY_ON_OFF_BLINK_OFF 0x00                         // Disable cursor blinking
+#define LCD_CURSOR_OR_DISPLAY_SHIFT_CURSOR_LEFT_DECREASE_AC 0x00  // Shift cursor to the left, AC is decreased by 1
+#define LCD_CURSOR_OR_DISPLAY_SHIFT_CURSOR_RIGHT_INCREASE_AC 0x01 // Shift cursor to the right, AC is increased by 1
+#define LCD_CURSOR_OR_DISPLAY_SHIFT_SHIFT_DISPLAY_LEFT 0x02       // Shift all the display to the left, Cursor moves according to the display
+#define LCD_CURSOR_OR_DISPLAY_SHIFT_SHIFT_DISPLAY_RIGHT 0x03      // Shift all the display to the right, cursor moves according to the display
+#define LCD_FUNCTION_SET_8_BIT 0x10                               // Enable 8-bit bus mode
+#define LCD_FUNCTION_SET_4_BIT 0x00                               // Enable 4-bit bus mode
+#define LCD_FUNCTION_SET_1_LINE 0x00                              // Enable 1-line display mode
+#define LCD_FUNCTION_SET_2_LINES 0x08                             // Enable 2-lines display mode - binary: 1000
+#define LCD_FUNCTION_SET_5X8 0x00                                 // Enable 5x8 font mode
+#define LCD_FUNCTION_SET_5X11 0x04                                // Enable 5x11 font mode
+
 void LCD_init(uint8_t addr, uint8_t cols, uint8_t rows);
 void LCD_setCursor(uint8_t col, uint8_t row);
 void LCD_home(void);

--- a/provisioning/esp32/smart_desk/components/i2c_manager/hd_44780.h
+++ b/provisioning/esp32/smart_desk/components/i2c_manager/hd_44780.h
@@ -71,6 +71,6 @@ void LCD_switchBacklightOn(void);
 void LCD_turnDisplayOff(void);
 void LCD_turnDisplayOn(void);
 void LCD_writeChar(char c);
-void LCD_writeStr(char *str);
+void LCD_writeStr(const char *str);
 
 void LCD_Demo();

--- a/provisioning/esp32/smart_desk/components/i2c_manager/hd_44780.h
+++ b/provisioning/esp32/smart_desk/components/i2c_manager/hd_44780.h
@@ -4,31 +4,22 @@
 #define LCD_LINETHREE 0x14 // Start of line 3
 #define LCD_LINEFOUR 0x54  // Start of line 4
 
-// Pin mappings
-// P0 -> RS
-// P1 -> RW
-// P2 -> E
-// P3 -> Backlight (b) <- not sure about this
-// P4 -> D4
-// P5 -> D5
-// P6 -> D6
-// P7 -> D7
+// Register select (instruction or data, RS bit)
+#define LCD_INSTRUCTION_REGISTER 0
+#define LCD_DATA_REGISTER 1
 
-// A0 backlight
-
-// Register select (data or instruction, RS bit)
-#define LCD_INSTRUCTION_REGISTER 0x00 // Instruction register
-#define LCD_DATA_REGISTER 0x01        // Data register - binary: 1
+#define LCD_SEND_4_BITS 0
+#define LCD_SEND_8_BITS 1
 
 // Command mode (read or write, R/W bit)
 #define LCD_WRITE_MODE 0x00 // Write data to the LCD display (I2C master -> I2C slave)
 #define LCD_READ_MODE 0x02  // Read data from the LCD display (I2C slave -> I2C master) - binary: 10
 
-// Enable bit
-#define LCD_ENABLE_ON 0x04 // Enable bit ON - binary: 100
-
-// Backlight bit
-#define LCD_BACKLIGHT_ON 0x08 // Enable LCD backlight - binary: 1000
+// LCD Backlight bits
+#define LCD_BACKLIGHT_ON_MASK 0xFF  // Backlight mask used when backlight is ON
+#define LCD_BACKLIGHT_OFF_MASK 0x00 // Backlight mask used when backlight is OFF
+#define BACKLIGHT_OFF 0             // Used in combination with the setBacklight to switch the LCD backlight OFF
+#define BACKLIGHT_ON 255            // Used in combination with the setBacklight to switch the LCD backlight ON
 
 // LCD commands
 #define LCD_CLEAR_DISPLAY 0x01           // Replace all characters with ASCII SP (space, code 32, 0x20) - binary: 1
@@ -37,36 +28,48 @@
 #define LCD_DISPLAY_ON_OFF 0x08          // Turn on or off the display, show or hide the cursor, turn on or off cursor blinking - binary: 1000
 #define LCD_CURSOR_OR_DISPLAY_SHIFT 0x10 // Shift cursor or display position (useful to search or to correct data)
 #define LCD_FUNCTION_SET 0x20            // Set 8-bit or 4-bit command mode, set 1-line or 2-line display mode, set 5x8 or 5x11 font mode - binary: 100000
-#define LCD_FUNCTION_RESET 0x30          // Reset the LCD - binary: 110000
 #define LCD_SET_CGRAM_ADDRESS 0x40       // Set CGRAM address
 #define LCD_SET_DDRAM_ADDRESS 0x80       // Set DDRAM address (cursor position) - binary: 10000000
 
-// LCD command parameters
-#define LCD_ENTRY_MODE_SET_INCREMENT_DDRAM_ADDRESS 0x02           // Cursor moves to right and DDRAM address is increased by 1
-#define LCD_ENTRY_MODE_SET_DECREMENT_DDRAM_ADDRESS 0x00           // Cursor moves to left and DDRAM address is decreased by 1
-#define LCD_ENTRY_MODE_SET_SHIFT_DISPLAY 0x01                     // When reading from DDRAM, or reading from or writing to CGRAM, shift the entire display according to increment or decrement
-#define LCD_ENTRY_MODE_SET_NO_SHIFT_DISPLAY 0x00                  // When reading from DDRAM, or reading from or writing to CGRAM, don't shift the entire display according to increment or decrement
-#define LCD_DISPLAY_ON_OFF_DISPLAY_ON 0x04                        // Turn the entire display on - binary: 100
-#define LCD_DISPLAY_ON_OFF_DISPLAY_OFF 0x00                       // Turn the entire display off, but data remains in DDRAM
-#define LCD_DISPLAY_ON_OFF_CURSOR_ON 0x02                         // Show the cursor - binary: 10
-#define LCD_DISPLAY_ON_OFF_CURSOR_OFF 0x00                        // Hide the cursor, but the cursor position register preserves data
-#define LCD_DISPLAY_ON_OFF_BLINK_ON 0x02                          // Enable cursor blinking
-#define LCD_DISPLAY_ON_OFF_BLINK_OFF 0x00                         // Disable cursor blinking
+// LCD reset command
+#define LCD_FUNCTION_RESET 0x30 // Reset the LCD controller - binary: 110000
+
+// LCD entry mode command parameters
+#define LCD_ENTRY_MODE_SET_INCREMENT_DDRAM_ADDRESS 0x02 // Cursor moves to right and DDRAM address is increased by 1
+#define LCD_ENTRY_MODE_SET_DECREMENT_DDRAM_ADDRESS 0x00 // Cursor moves to left and DDRAM address is decreased by 1
+#define LCD_ENTRY_MODE_SET_SHIFT_DISPLAY 0x01           // When reading from DDRAM, or reading from or writing to CGRAM, shift the entire display according to increment or decrement
+#define LCD_ENTRY_MODE_SET_NO_SHIFT_DISPLAY 0x00        // When reading from DDRAM, or reading from or writing to CGRAM, don't shift the entire display according to increment or decrement
+
+// LCD display on/off command parameters
+#define LCD_DISPLAY_ON_OFF_DISPLAY_ON 0x04  // Turn the entire display on - binary: 100
+#define LCD_DISPLAY_ON_OFF_DISPLAY_OFF 0x00 // Turn the entire display off, but data remains in DDRAM
+#define LCD_DISPLAY_ON_OFF_CURSOR_ON 0x02   // Show the cursor - binary: 10
+#define LCD_DISPLAY_ON_OFF_CURSOR_OFF 0x00  // Hide the cursor, but the cursor position register preserves data
+#define LCD_DISPLAY_ON_OFF_BLINK_ON 0x01    // Enable cursor blinking
+#define LCD_DISPLAY_ON_OFF_BLINK_OFF 0x00   // Disable cursor blinking
+
+// LCD shift command parameters
 #define LCD_CURSOR_OR_DISPLAY_SHIFT_CURSOR_LEFT_DECREASE_AC 0x00  // Shift cursor to the left, AC is decreased by 1
 #define LCD_CURSOR_OR_DISPLAY_SHIFT_CURSOR_RIGHT_INCREASE_AC 0x01 // Shift cursor to the right, AC is increased by 1
 #define LCD_CURSOR_OR_DISPLAY_SHIFT_SHIFT_DISPLAY_LEFT 0x02       // Shift all the display to the left, Cursor moves according to the display
 #define LCD_CURSOR_OR_DISPLAY_SHIFT_SHIFT_DISPLAY_RIGHT 0x03      // Shift all the display to the right, cursor moves according to the display
-#define LCD_FUNCTION_SET_8_BIT 0x10                               // Enable 8-bit bus mode
-#define LCD_FUNCTION_SET_4_BIT 0x00                               // Enable 4-bit bus mode
-#define LCD_FUNCTION_SET_1_LINE 0x00                              // Enable 1-line display mode
-#define LCD_FUNCTION_SET_2_LINES 0x08                             // Enable 2-lines display mode - binary: 1000
-#define LCD_FUNCTION_SET_5X8 0x00                                 // Enable 5x8 font mode
-#define LCD_FUNCTION_SET_5X11 0x04                                // Enable 5x11 font mode
 
-void LCD_init(uint8_t addr, uint8_t cols, uint8_t rows);
+// LCD function parameters
+#define LCD_FUNCTION_SET_8_BIT 0x10   // Enable 8-bit bus mode
+#define LCD_FUNCTION_SET_4_BIT 0x00   // Enable 4-bit bus mode
+#define LCD_FUNCTION_SET_1_LINE 0x00  // Enable 1-line display mode
+#define LCD_FUNCTION_SET_2_LINES 0x08 // Enable 2-lines display mode - binary: 1000
+#define LCD_FUNCTION_SET_5X8 0x00     // Enable 5x8 font mode
+#define LCD_FUNCTION_SET_5X11 0x04    // Enable 5x11 font mode
+
+void LCD_init(uint8_t addr, uint8_t cols, uint8_t rows, uint8_t En, uint8_t Rw, uint8_t Rs, uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7, uint8_t backlighPin);
 void LCD_setCursor(uint8_t col, uint8_t row);
 void LCD_home(void);
 void LCD_clearScreen(void);
+void LCD_switchBacklightOff(void);
+void LCD_switchBacklightOn(void);
+void LCD_turnDisplayOff(void);
+void LCD_turnDisplayOn(void);
 void LCD_writeChar(char c);
 void LCD_writeStr(char *str);
 

--- a/provisioning/esp32/smart_desk/components/i2c_manager/hd_44780.h
+++ b/provisioning/esp32/smart_desk/components/i2c_manager/hd_44780.h
@@ -1,0 +1,8 @@
+void LCD_init(uint8_t addr, uint8_t cols, uint8_t rows);
+void LCD_setCursor(uint8_t col, uint8_t row);
+void LCD_home(void);
+void LCD_clearScreen(void);
+void LCD_writeChar(char c);
+void LCD_writeStr(char *str);
+
+void LCD_Demo();

--- a/provisioning/esp32/smart_desk/components/i2c_manager/i2c_utils.c
+++ b/provisioning/esp32/smart_desk/components/i2c_manager/i2c_utils.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include "driver/i2c.h"
+#include "esp_log.h"
+
+#include "i2c_utils.h"
+
+#define ACK_CHECK_EN 0x1 // I2C master will check ack from slave
+
+static const char *TAG = "i2c_utils";
+
+i2c_port_t i2c_port = I2C_NUM_0;
+
+void i2c_master_driver_initialize(uint8_t sda_pin, uint8_t scl_pin, uint8_t i2c_frequency)
+{
+    i2c_config_t conf = {
+        .mode = I2C_MODE_MASTER,
+        .sda_io_num = sda_pin,
+        .sda_pullup_en = GPIO_PULLUP_ENABLE,
+        .scl_io_num = scl_pin,
+        .scl_pullup_en = GPIO_PULLUP_ENABLE,
+        .master.clk_speed = i2c_frequency};
+
+    ESP_ERROR_CHECK(i2c_param_config(i2c_port, &conf));
+    ESP_ERROR_CHECK(i2c_driver_install(i2c_port, I2C_MODE_MASTER, 0, 0, 0));
+}
+
+int do_i2cdetect()
+{
+    ESP_LOGI(TAG, "Detecting I2C devices...");
+    uint8_t address;
+    printf("     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f\r\n");
+    for (int i = 0; i < 128; i += 16)
+    {
+        printf("%02x: ", i);
+        for (int j = 0; j < 16; j++)
+        {
+            fflush(stdout);
+            address = i + j;
+            i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+            i2c_master_start(cmd);
+            i2c_master_write_byte(cmd, (address << 1) | I2C_MASTER_WRITE, ACK_CHECK_EN);
+            i2c_master_stop(cmd);
+            esp_err_t ret = i2c_master_cmd_begin(i2c_port, cmd, 50 / portTICK_RATE_MS);
+            i2c_cmd_link_delete(cmd);
+            if (ret == ESP_OK)
+            {
+                printf("%02x ", address);
+            }
+            else if (ret == ESP_ERR_TIMEOUT)
+            {
+                printf("UU ");
+            }
+            else
+            {
+                printf("-- ");
+            }
+        }
+        printf("\r\n");
+    }
+
+    return 0;
+}

--- a/provisioning/esp32/smart_desk/components/i2c_manager/i2c_utils.c
+++ b/provisioning/esp32/smart_desk/components/i2c_manager/i2c_utils.c
@@ -3,6 +3,7 @@
 #include "esp_log.h"
 
 #include "i2c_utils.h"
+#include "print_utils.h"
 
 #define ACK_CHECK_EN 0x1 // I2C master will check ack from slave
 
@@ -22,6 +23,18 @@ void i2c_master_driver_initialize(uint8_t sda_pin, uint8_t scl_pin, uint8_t i2c_
 
     ESP_ERROR_CHECK(i2c_param_config(i2c_port, &conf));
     ESP_ERROR_CHECK(i2c_driver_install(i2c_port, I2C_MODE_MASTER, 0, 0, 0));
+}
+
+void i2c_master_write_byte_to_client_ack(uint8_t client_address, uint8_t data)
+{
+    ESP_LOGI(TAG, "Writing to client 0x%02x. Sending byte: " BYTE_TO_BINARY_PATTERN, client_address, BYTE_TO_BINARY(data));
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    ESP_ERROR_CHECK(i2c_master_start(cmd));
+    ESP_ERROR_CHECK(i2c_master_write_byte(cmd, (client_address << 1) | I2C_MASTER_WRITE, 1));
+    ESP_ERROR_CHECK(i2c_master_write_byte(cmd, data, 1));
+    ESP_ERROR_CHECK(i2c_master_stop(cmd));
+    ESP_ERROR_CHECK(i2c_master_cmd_begin(I2C_NUM_0, cmd, 1000 / portTICK_PERIOD_MS));
+    i2c_cmd_link_delete(cmd);
 }
 
 int do_i2cdetect()
@@ -53,6 +66,132 @@ int do_i2cdetect()
             else
             {
                 printf("-- ");
+            }
+        }
+        printf("\r\n");
+    }
+
+    return 0;
+}
+
+int do_i2cget(uint8_t chip_address, int8_t register_address, uint8_t data_length)
+{
+    uint8_t *data = malloc(data_length);
+
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    if (register_address != -1)
+    {
+        i2c_master_write_byte(cmd, chip_address << 1 | I2C_MASTER_WRITE, ACK_CHECK_EN);
+        i2c_master_write_byte(cmd, register_address, ACK_CHECK_EN);
+        i2c_master_start(cmd);
+    }
+    i2c_master_write_byte(cmd, chip_address << 1 | I2C_MASTER_READ, ACK_CHECK_EN);
+    if (data_length > 1)
+    {
+        i2c_master_read(cmd, data, data_length - 1, 0x0);
+    }
+    i2c_master_read_byte(cmd, data + data_length - 1, 0x1);
+    i2c_master_stop(cmd);
+    esp_err_t ret = i2c_master_cmd_begin(i2c_port, cmd, 1000 / portTICK_RATE_MS);
+    i2c_cmd_link_delete(cmd);
+    if (ret == ESP_OK)
+    {
+        for (int i = 0; i < data_length; i++)
+        {
+            printf("0x%02x ", data[i]);
+            if ((i + 1) % 16 == 0)
+            {
+                printf("\r\n");
+            }
+        }
+        if (data_length % 16)
+        {
+            printf("\r\n");
+        }
+    }
+    else if (ret == ESP_ERR_TIMEOUT)
+    {
+        ESP_LOGW(TAG, "Bus is busy");
+    }
+    else
+    {
+        ESP_LOGW(TAG, "Read failed");
+    }
+    free(data);
+    return 0;
+}
+
+int do_i2cdump(uint8_t chip_address, uint8_t read_size)
+{
+    ESP_LOGI(TAG, "Dumping I2C registries...");
+    if (read_size != 1 && read_size != 2 && read_size != 4)
+    {
+        ESP_LOGE(TAG, "Wrong read size. Only support 1,2,4");
+        return 1;
+    }
+
+    uint8_t data_addr;
+    uint8_t data[4];
+    int32_t block[16];
+    printf("     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f"
+           "    0123456789abcdef\r\n");
+    for (int i = 0; i < 128; i += 16)
+    {
+        printf("%02x: ", i);
+        for (int j = 0; j < 16; j += read_size)
+        {
+            fflush(stdout);
+            data_addr = i + j;
+            i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+            i2c_master_start(cmd);
+            i2c_master_write_byte(cmd, chip_address << 1 | I2C_MASTER_WRITE, ACK_CHECK_EN);
+            i2c_master_write_byte(cmd, data_addr, ACK_CHECK_EN);
+            i2c_master_start(cmd);
+            i2c_master_write_byte(cmd, chip_address << 1 | I2C_MASTER_READ, ACK_CHECK_EN);
+            if (read_size > 1)
+            {
+                i2c_master_read(cmd, data, read_size - 1, 0x0);
+            }
+            i2c_master_read_byte(cmd, data + read_size - 1, 0x1);
+            i2c_master_stop(cmd);
+            esp_err_t ret = i2c_master_cmd_begin(i2c_port, cmd, 50 / portTICK_RATE_MS);
+            i2c_cmd_link_delete(cmd);
+            if (ret == ESP_OK)
+            {
+                for (int k = 0; k < read_size; k++)
+                {
+                    printf("%02x ", data[k]);
+                    block[j + k] = data[k];
+                }
+            }
+            else
+            {
+                for (int k = 0; k < read_size; k++)
+                {
+                    printf("XX ");
+                    block[j + k] = -1;
+                }
+            }
+        }
+        printf("   ");
+        for (int k = 0; k < 16; k++)
+        {
+            if (block[k] < 0)
+            {
+                printf("X");
+            }
+            if ((block[k] & 0xff) == 0x00 || (block[k] & 0xff) == 0xff)
+            {
+                printf(".");
+            }
+            else if ((block[k] & 0xff) < 32 || (block[k] & 0xff) >= 127)
+            {
+                printf("?");
+            }
+            else
+            {
+                printf("%c", block[k] & 0xff);
             }
         }
         printf("\r\n");

--- a/provisioning/esp32/smart_desk/components/i2c_manager/i2c_utils.h
+++ b/provisioning/esp32/smart_desk/components/i2c_manager/i2c_utils.h
@@ -1,0 +1,2 @@
+void i2c_master_driver_initialize(uint8_t sda_pin, uint8_t scl_pin, uint8_t i2c_frequency);
+int do_i2cdetect();

--- a/provisioning/esp32/smart_desk/components/i2c_manager/i2c_utils.h
+++ b/provisioning/esp32/smart_desk/components/i2c_manager/i2c_utils.h
@@ -1,2 +1,5 @@
 void i2c_master_driver_initialize(uint8_t sda_pin, uint8_t scl_pin, uint8_t i2c_frequency);
+void i2c_master_write_byte_to_client_ack(uint8_t client_address, uint8_t data);
 int do_i2cdetect();
+int do_i2cget(uint8_t chip_address, int8_t register_address, uint8_t data_length);
+int do_i2cdump(uint8_t chip_address, uint8_t read_size);

--- a/provisioning/esp32/smart_desk/main/CMakeLists.txt
+++ b/provisioning/esp32/smart_desk/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "smart_desk_main.c"
     INCLUDE_DIRS ""
-    REQUIRES debug_utils network_manager storage_manager provisioning_manager)
+    REQUIRES debug_utils i2c_manager network_manager storage_manager provisioning_manager)

--- a/provisioning/esp32/smart_desk/main/smart_desk_main.c
+++ b/provisioning/esp32/smart_desk/main/smart_desk_main.c
@@ -8,15 +8,33 @@
 
 #include "app_info.h"
 #include "board_info.h"
+#include "i2c_utils.h"
+#include "hd_44780.h"
 
 #include "ip_address_manager.h"
 #include "wifi_connection_manager.h"
 #include "provisioning_manager.h"
 
+#define SDA_PIN 23
+#define SCL_PIN 22
+#define I2C_FREQUENCY ((uint8_t)100000)
+
+#define LCD_ADDR 0x27
+#define LCD_COLS 20
+#define LCD_ROWS 4
+
 static const char *TAG = "smart_desk";
 
 void app_main(void)
 {
+    i2c_master_driver_initialize(SDA_PIN, SCL_PIN, I2C_FREQUENCY);
+    do_i2cdetect();
+
+    LCD_init(LCD_ADDR, LCD_COLS, LCD_ROWS);
+
+    ESP_LOGI(TAG, "Showing LCD demo...");
+    LCD_Demo();
+
     esp_chip_info_t chip_info;
     esp_chip_info(&chip_info);
     const char *board_info = get_board_info(chip_info, spi_flash_get_chip_size(), esp_get_free_heap_size());

--- a/provisioning/esp32/smart_desk/main/smart_desk_main.c
+++ b/provisioning/esp32/smart_desk/main/smart_desk_main.c
@@ -30,7 +30,16 @@ void app_main(void)
     i2c_master_driver_initialize(SDA_PIN, SCL_PIN, I2C_FREQUENCY);
     do_i2cdetect();
 
-    LCD_init(LCD_ADDR, LCD_COLS, LCD_ROWS);
+    // i2c expander - LCD Pin mappings
+    // P0 -> RS
+    // P1 -> RW
+    // P2 -> E
+    // P3 -> Backlight (b) <- not sure about this
+    // P4 -> D4
+    // P5 -> D5
+    // P6 -> D6
+    // P7 -> D7
+    LCD_init(LCD_ADDR, LCD_COLS, LCD_ROWS, 2, 1, 0, 4, 5, 6, 7, 3);
     LCD_Demo();
 
     esp_chip_info_t chip_info;

--- a/provisioning/esp32/smart_desk/main/smart_desk_main.c
+++ b/provisioning/esp32/smart_desk/main/smart_desk_main.c
@@ -40,7 +40,12 @@ void app_main(void)
     // P6 -> D6
     // P7 -> D7
     LCD_init(LCD_ADDR, LCD_COLS, LCD_ROWS, 2, 1, 0, 4, 5, 6, 7, 3);
-    LCD_Demo();
+    LCD_clearScreen();
+    LCD_home();
+    LCD_turnDisplayOn();
+    LCD_switchBacklightOn();
+
+    LCD_writeStr("Initializing...");
 
     esp_chip_info_t chip_info;
     esp_chip_info(&chip_info);

--- a/provisioning/esp32/smart_desk/main/smart_desk_main.c
+++ b/provisioning/esp32/smart_desk/main/smart_desk_main.c
@@ -31,8 +31,6 @@ void app_main(void)
     do_i2cdetect();
 
     LCD_init(LCD_ADDR, LCD_COLS, LCD_ROWS);
-
-    ESP_LOGI(TAG, "Showing LCD demo...");
     LCD_Demo();
 
     esp_chip_info_t chip_info;


### PR DESCRIPTION
This PR adds support for controlling a HD44780 LCD display with an ESP32, via I2C.