### PR TITLE
Show IP address on the LCD

### DIFF
--- a/provisioning/esp32/smart_desk/components/i2c_manager/hd_44780.c
+++ b/provisioning/esp32/smart_desk/components/i2c_manager/hd_44780.c
@@ -312,6 +312,9 @@ static void sta_got_ip_event_handler(void *arg, esp_event_base_t event_base, int
 
     ESP_LOGI(TAG, "Got IP address: %s", ip_info);
     ESP_LOGI(TAG, "Writing %s to the LCD display...", ip_info);
+
+    LCD_clearScreen();
+    LCD_home();
     LCD_writeStr(ip_info);
 }
 

--- a/provisioning/esp32/smart_desk/components/i2c_manager/hd_44780.h
+++ b/provisioning/esp32/smart_desk/components/i2c_manager/hd_44780.h
@@ -74,3 +74,5 @@ void LCD_writeChar(char c);
 void LCD_writeStr(const char *str);
 
 void LCD_Demo();
+
+void register_lcd_events();

--- a/provisioning/esp32/smart_desk/main/smart_desk_main.c
+++ b/provisioning/esp32/smart_desk/main/smart_desk_main.c
@@ -62,6 +62,10 @@ void app_main(void)
     register_wifi_manager_event_handlers();
     register_ip_address_manager_event_handlers();
     register_provisioning_manager_event_handlers();
+    register_lcd_events();
+
+    LCD_clearScreen();
+    LCD_home();
 
     start_wifi_provisioning();
 }


### PR DESCRIPTION
This PR adds an event handler that reacts writing the current IP address on the LCD display.