### PR TITLE
Configure Renovate bot for Docker Compose and Ansible

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,22 @@
+{
+  "dryRun": true,
+  "enabledManagers": [
+    "ansible",
+    "docker-compose"
+  ],
+  "dockerfile": {
+    "fileMatch": [
+      "(^|\/)(?:docker-)?compose[^\/]*\\.ya?ml(?:\\.jinja)$"
+    ]
+  },
+  "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
+  "includeForks": true,
+  "onboarding": false,
+  "platform": "github",
+  "repositories": [
+    "renovatebot/github-action",
+    "renovate-tests/cocoapods1",
+    "renovate-tests/gomod1"
+  ],
+  "username": "renovate-release"
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,10 +13,5 @@
   "includeForks": true,
   "onboarding": false,
   "platform": "github",
-  "repositories": [
-    "renovatebot/github-action",
-    "renovate-tests/cocoapods1",
-    "renovate-tests/gomod1"
-  ],
   "username": "renovate-release"
 }

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,20 @@
+---
+name: Renovate
+
+on:
+  schedule:
+    - cron: "0/15 * * * *"
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v32.229.0
+        with:
+          configurationFile: .github/renovate.json
+          token: ${{ secrets.RENOVATE_TOKEN }}
+...

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,10 +1,10 @@
 ---
 name: Renovate
 
-on:
+on:  # yamllint disable-line rule:truthy
   schedule:
-    - cron: "0/15 * * * *"
-  workflow_dispatch:
+    - cron: "0 2 * * *"
+  workflow_dispatch: null
 
 jobs:
   renovate:


### PR DESCRIPTION
Configure Renovate CLI, running as a GitHub Action, to create PRs for container image versions in Docker Compose and Ansible files. We use DependaBot for everything else.