### PR TITLE
Pull the needed container images without necessarily starting containers

### DIFF
--- a/docker/ansible/etc/ansible/roles/ferrarimarco_home_lab_node/tasks/include-variables.yaml
+++ b/docker/ansible/etc/ansible/roles/ferrarimarco_home_lab_node/tasks/include-variables.yaml
@@ -39,6 +39,7 @@
         fact_os_packages_to_install: "{{ item.fact_os_packages_to_install | default([]) }}"
         fact_os_packages_to_uninstall: "{{ item.fact_os_packages_to_uninstall | default([]) }}"
         fact_os_services_to_configure: "{{ item.fact_os_services_to_configure | default([]) }}"
+        fact_start_containerized_services: "{{ item.fact_start_containerized_services | default(item.enable_custom_fact) }}"
         fact_templates_to_render: "{{ item.fact_templates_to_render | default([]) }}"
     file: register-custom-facts.yaml
   when: item.enable_custom_fact | default(true)

--- a/docker/ansible/etc/ansible/roles/ferrarimarco_home_lab_node/tasks/invoke-system-wide-configuration-handlers.yaml
+++ b/docker/ansible/etc/ansible/roles/ferrarimarco_home_lab_node/tasks/invoke-system-wide-configuration-handlers.yaml
@@ -15,6 +15,22 @@
     state: "restarted"
   with_items: "{{ os_services_to_restart | unique }}"
 
+- name: Pull container images
+  debugger: on_failed
+  changed_when: '"Pull complete" in docker_compose_pull_result.stdout or "Pull complete" in docker_compose_pull_result.stderr'
+  ansible.builtin.command: >
+    docker compose \
+    --file {{ item.compose_file_path }} \
+    pull \
+    --include-deps
+  register: docker_compose_pull_result
+  with_items: "{{ docker_compose_up_items | unique }}"
+
+- name: Debug Docker Compose pull output
+  ansible.builtin.debug:
+    var: docker_compose_pull_result
+    verbosity: 1
+
 - name: Start Docker Compose services
   debugger: on_failed
   changed_when: '"Started" in docker_compose_up_result.stdout or "Started" in docker_compose_up_result.stderr'

--- a/docker/ansible/etc/ansible/roles/ferrarimarco_home_lab_node/tasks/invoke-system-wide-configuration-handlers.yaml
+++ b/docker/ansible/etc/ansible/roles/ferrarimarco_home_lab_node/tasks/invoke-system-wide-configuration-handlers.yaml
@@ -42,6 +42,7 @@
     --detach \
     --remove-orphans
   register: docker_compose_up_result
+  when: item.start_containerized_service
   with_items: "{{ docker_compose_up_items | unique }}"
 
 - name: Debug Docker Compose up output

--- a/docker/ansible/etc/ansible/roles/ferrarimarco_home_lab_node/tasks/register-custom-facts.yaml
+++ b/docker/ansible/etc/ansible/roles/ferrarimarco_home_lab_node/tasks/register-custom-facts.yaml
@@ -1,4 +1,25 @@
 ---
+- name: Debug fact_docker_compose_up_items for {{ fact_category }}
+  ansible.builtin.debug:
+    var: fact_docker_compose_up_items
+    verbosity: 1
+
+- name: Initialize the start containerized services flag list for {{ fact_category }}
+  ansible.builtin.set_fact:
+    fact_docker_compose_up_items_with_start_flag: []
+
+- name: Configure the start containerized services flag for {{ fact_category }}
+  ansible.builtin.set_fact:
+    fact_docker_compose_up_items_with_start_flag: "{{ fact_docker_compose_up_items_with_start_flag + [fact_docker_compose_up_items_with_start_flag_item | combine({'start_containerized_service': fact_start_containerized_services})] }}"
+  with_items: "{{ fact_docker_compose_up_items }}"
+  loop_control:
+    loop_var: fact_docker_compose_up_items_with_start_flag_item
+
+- name: Debug fact_docker_compose_up_items_with_start_flag for {{ fact_category }}
+  ansible.builtin.debug:
+    var: fact_docker_compose_up_items_with_start_flag
+    verbosity: 1
+
 - name: Register facts for {{ fact_category }}
   ansible.builtin.set_fact:
     apt_packages_to_install: "{{ apt_packages_to_install + fact_os_packages_to_install }}"
@@ -9,7 +30,7 @@
     configuration_directories_to_create: "{{ configuration_directories_to_create + fact_configuration_directories_to_create }}"
     cron_jobs: "{{ cron_jobs + fact_cron_jobs }}"
     deb_packages_to_install: "{{ deb_packages_to_install + fact_deb_packages_to_install }}"
-    docker_compose_up_items: "{{ docker_compose_up_items + fact_docker_compose_up_items }}"
+    docker_compose_up_items: "{{ docker_compose_up_items + fact_docker_compose_up_items_with_start_flag }}"
     files_to_download: "{{ files_to_download + fact_files_to_download }}"
     files_to_remove: "{{ files_to_remove + fact_files_to_remove }}"
     os_groups_to_create: "{{ os_groups_to_create + fact_os_groups_to_create }}"


### PR DESCRIPTION
This is useful in host-to-host container migration scenarios to shorten downtimes.