### PR TITLE
Simplify CI jobs to only run linting when needed

### DIFF
--- a/.github/workflows/build-container-images.yaml
+++ b/.github/workflows/build-container-images.yaml
@@ -8,22 +8,16 @@ on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - ".github/workflows/build-container-images.yaml"
-      - ".github/workflows/lint.yaml"
       - "docker/**"
   pull_request:
     paths:
       - ".github/workflows/build-container-images.yaml"
-      - ".github/workflows/lint.yaml"
       - "docker/**"
 
 jobs:
-  lint:
-    uses: ./.github/workflows/lint.yaml
   build-container-images:
     env:
       CONTAINER_IMAGE_ID: "${{ github.repository }}-${{ matrix.container-image-context-directory }}"
-    needs:
-      - lint
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-firmware-images.yaml
+++ b/.github/workflows/build-firmware-images.yaml
@@ -8,23 +8,17 @@ on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - ".github/workflows/build-firmware-images.yaml"
-      - ".github/workflows/lint.yaml"
       - "config/smart-desk/**"
   pull_request:
     paths:
       - ".github/workflows/build-firmware-images.yaml"
-      - ".github/workflows/lint.yaml"
       - "config/smart-desk/**"
 
 jobs:
-  lint:
-    uses: ./.github/workflows/lint.yaml
   build-smart-desk:
     defaults:
       run:
         working-directory: config/smart-desk/esphome
-    needs:
-      - lint
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-os-images.yaml
+++ b/.github/workflows/build-os-images.yaml
@@ -8,26 +8,20 @@ on:  # yamllint disable-line rule:truthy
   push:
     paths:
       - ".github/workflows/build-os-images.yaml"
-      - ".github/workflows/lint.yaml"
       - "config/raspberry-pi/**"
       - "config/seed-device/**"
       - "docker/os-image-builder/**"
   pull_request:
     paths:
       - ".github/workflows/build-os-images.yaml"
-      - ".github/workflows/lint.yaml"
       - "config/raspberry-pi/**"
       - "config/seed-device/**"
       - "docker/os-image-builder/**"
 
 jobs:
-  lint:
-    uses: ./.github/workflows/lint.yaml
   customize-preinstalled-os-images:
     env:
       OS_BUILDER_CONTAINER_IMAGE_ID: "ferrarimarco/os-image-builder:latest"
-    needs:
-      - lint
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Don't run `lint` jobs multiple times, but only once.