### PR TITLE
Set hostname when running Restic containers to make pruning work

### DIFF
--- a/docker/ansible/etc/ansible/roles/ferrarimarco_home_lab_node/templates/restic/compose.yaml.jinja
+++ b/docker/ansible/etc/ansible/roles/ferrarimarco_home_lab_node/templates/restic/compose.yaml.jinja
@@ -5,13 +5,13 @@ services:
     image: home-lab-restic:latest
     build:
       context: .
-    container_name: "{{ backup_job.job_name }}-{{ inventory_hostname }}"
+    container_name: "{{ backup_job.job_name }}"
     environment:
       - RESTIC_DIRECTORIES_TO_BACKUP={{ backup_job.directories_to_backup | join(' ', attribute='container_mount_destination_directory') }}
       - RESTIC_FORGET_POLICY={{ backup_job.restic_forget_policy | join(' ') }}
       - RESTIC_REPOSITORY=/var/lib/restic/repository
       - RESTIC_PASSWORD="{{ backup_job.restic_repository_password }}"
-    hostname: "{{ backup_job.job_name }}"
+    hostname: "{{ backup_job.job_name }}-{{ inventory_hostname }}"
     restart: on-failure
     volumes:
       - {{ backup_job.restic_repository_host_path }}:/var/lib/restic/repository

--- a/docker/ansible/etc/ansible/roles/ferrarimarco_home_lab_node/templates/restic/compose.yaml.jinja
+++ b/docker/ansible/etc/ansible/roles/ferrarimarco_home_lab_node/templates/restic/compose.yaml.jinja
@@ -5,7 +5,7 @@ services:
     image: home-lab-restic:latest
     build:
       context: .
-    container_name: "{{ backup_job.job_name }}"
+    container_name: "{{ backup_job.job_name }}-{{ inventory_hostname }}"
     environment:
       - RESTIC_DIRECTORIES_TO_BACKUP={{ backup_job.directories_to_backup | join(' ', attribute='container_mount_destination_directory') }}
       - RESTIC_FORGET_POLICY={{ backup_job.restic_forget_policy | join(' ') }}

--- a/docker/ansible/etc/ansible/roles/ferrarimarco_home_lab_node/templates/restic/compose.yaml.jinja
+++ b/docker/ansible/etc/ansible/roles/ferrarimarco_home_lab_node/templates/restic/compose.yaml.jinja
@@ -11,6 +11,7 @@ services:
       - RESTIC_FORGET_POLICY={{ backup_job.restic_forget_policy | join(' ') }}
       - RESTIC_REPOSITORY=/var/lib/restic/repository
       - RESTIC_PASSWORD="{{ backup_job.restic_repository_password }}"
+    hostname: "{{ backup_job.job_name }}"
     restart: on-failure
     volumes:
       - {{ backup_job.restic_repository_host_path }}:/var/lib/restic/repository


### PR DESCRIPTION
Restic groups by host and source path by default when pruning snapshots, so setting a consistent hostname is needed to correctly identify the host that's running the backup job.