### PR TITLE
Don't configure prometheus scraping using default vars

### DIFF
--- a/docker/ansible/etc/ansible/roles/ferrarimarco_home_lab_node/templates/monitoring/compose.yaml.jinja
+++ b/docker/ansible/etc/ansible/roles/ferrarimarco_home_lab_node/templates/monitoring/compose.yaml.jinja
@@ -4,14 +4,14 @@ services:
     image: quay.io/prometheus/node-exporter:v1.5.0
     container_name: node_exporter
     command:
-      - "--collector.textfile.directory=/var/lib/node_exporter/textfile_collector"
+      - "--collector.textfile.directory={{ monitoring_prometheus_node_exporter_textfile_collector_directory }}"
       - "--path.rootfs=/host"
     network_mode: host
     pid: host
     restart: always
     volumes:
       - "/:/host:ro,rslave"
-      - /var/lib/node_exporter/textfile_collector:/var/lib/node_exporter/textfile_collector
+      - {{ monitoring_prometheus_node_exporter_textfile_collector_directory }}:{{ monitoring_prometheus_node_exporter_textfile_collector_directory }}
 {% if configure_docker %}
   cadvisor:
     container_name: cadvisor

--- a/docker/ansible/etc/ansible/roles/ferrarimarco_home_lab_node/templates/prometheus/prometheus.yaml.jinja
+++ b/docker/ansible/etc/ansible/roles/ferrarimarco_home_lab_node/templates/prometheus/prometheus.yaml.jinja
@@ -19,7 +19,7 @@ scrape_configs:
     static_configs:
       - targets:
 {% for host in groups['all'] %}
-{% if hostvars[host].enable_prometheus_node_exporter_scraping | default(enable_prometheus_node_exporter_scraping) %}
+{% if hostvars[host].enable_prometheus_node_exporter_scraping | default(true) %}
         - "{{ host }}:{{ prometheus_node_exporter_port }}"
 {% endif %}
 {% endfor %}
@@ -28,7 +28,7 @@ scrape_configs:
     static_configs:
       - targets:
 {% for host in groups['all'] %}
-{% if hostvars[host].configure_docker | default(configure_docker) %}
+{% if hostvars[host].configure_docker | default(false) %}
         - "{{ host }}:{{ hostvars[host].cadvisor_exposed_port | default(cadvisor_exposed_port) }}"
 {% endif %}
 {% endfor %}
@@ -112,7 +112,7 @@ scrape_configs:
     static_configs:
       - targets:
 {% for host in groups['all'] %}
-{% if hostvars[host].configure_network_stack | default(configure_network_stack) %}
+{% if hostvars[host].configure_network_stack | default(false) %}
         - "{{ host }}:{{ hostvars[host].network_stack_coredns_prometheus_metrics_port | default(network_stack_coredns_prometheus_metrics_port) }}"
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
Don't fallback on host vars to check if prometheus should scrape a particular target because that target might not run that particular exporter.