### PR TITLE
Refactor smart-desk firmware

### DIFF
--- a/.github/workflows/build-firmware-images.yaml
+++ b/.github/workflows/build-firmware-images.yaml
@@ -19,37 +19,13 @@ jobs:
     defaults:
       run:
         working-directory: config/smart-desk/esphome
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: "Build the Smart Desk firmware image"
         run: |
           scripts/build.sh
-      - uses: actions/upload-artifact@v3
-        with:
-          if-no-files-found: error
-          name: smart-desk.bin.xz
-          # working-directory has no effect on this action, so we need to set the full path anyway.
-          # See https://github.com/actions/upload-artifact/issues/246
-          path: |
-            config/smart-desk/esphome/.esphome/build/smart-desk/.pioenvs/smart-desk/firmware-factory.bin.xz
   update-release-draft:
     if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/draft-release.yaml
-  upload-images-to-release:
-    needs:
-      - build-smart-desk
-      - update-release-draft
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Download artifacts to upload
-        uses: actions/download-artifact@v3
-      - name: "Upload artifacts to the ${{ needs.update-release-draft.outputs.release-tag-name }} release"
-        run: |
-          ls ./**/*.${{ matrix.artifact-file-extension }}  >/dev/null && gh release upload "${{ needs.update-release-draft.outputs.release-tag-name }}" ./**/*.${{ matrix.artifact-file-extension }} --clobber
-    strategy:
-      matrix:
-        artifact-file-extension:
-          - xz
 ...

--- a/config/lint/.gitleaks.toml
+++ b/config/lint/.gitleaks.toml
@@ -2,4 +2,4 @@
 useDefault = true
 
 [allowlist]
-paths = ['''\.venv''', '''.*\/\.venv.*\/.*''']
+paths = ['''\.venv''', '''.*\/\.venv.*\/.*''', '''secrets-template.yaml''']

--- a/config/smart-desk/esphome/secrets-template.yaml
+++ b/config/smart-desk/esphome/secrets-template.yaml
@@ -1,6 +1,6 @@
 ---
 # Customize the following values as needed
-esphome_api_encryption_key: "esphome_api_encryption_key"
+esphome_api_encryption_key: "ZXNwaG9tZV9hcGlfZW5jcnlwdGlvbl9rZXkK"
 esphome_ota_password: "esphome_ota_password"
 wifi_fallback_hostspot_password: "fallback_hotspot_password"
 wifi_password: "wifi_password"

--- a/config/smart-desk/esphome/secrets-template.yaml
+++ b/config/smart-desk/esphome/secrets-template.yaml
@@ -1,6 +1,5 @@
 ---
 # Customize the following values as needed
-esphome_api_encryption_key: "ZXNwaG9tZV9hcGlfZW5jcnlwdGlvbl9rZXkK"
 esphome_ota_password: "esphome_ota_password"
 wifi_fallback_hostspot_password: "fallback_hotspot_password"
 wifi_password: "wifi_password"

--- a/config/smart-desk/esphome/secrets-template.yaml
+++ b/config/smart-desk/esphome/secrets-template.yaml
@@ -1,6 +1,7 @@
 ---
 # Customize the following values as needed
-home_assistant_api_key: "home_assistant_api_key"
+esphome_api_encryption_key: "esphome_api_encryption_key"
+esphome_ota_password: "esphome_ota_password"
 wifi_fallback_hostspot_password: "fallback_hotspot_password"
 wifi_password: "wifi_password"
 wifi_ssid: "wifi_ssid"

--- a/config/smart-desk/esphome/secrets-template.yaml
+++ b/config/smart-desk/esphome/secrets-template.yaml
@@ -1,5 +1,6 @@
 ---
 # Customize the following values as needed
+esphome_api_encryption_key: "g2jF6JiWbKtL1tQd32XoGwDYqq503MjDe4xqJbQc4to="
 esphome_ota_password: "esphome_ota_password"
 wifi_fallback_hostspot_password: "fallback_hotspot_password"
 wifi_password: "wifi_password"

--- a/config/smart-desk/esphome/smart-desk.yaml
+++ b/config/smart-desk/esphome/smart-desk.yaml
@@ -1,8 +1,6 @@
 ---
 # Enable Home Assistant API
-api:
-  encryption:
-    key: !secret esphome_api_encryption_key
+api: null
 
 captive_portal: null
 

--- a/config/smart-desk/esphome/smart-desk.yaml
+++ b/config/smart-desk/esphome/smart-desk.yaml
@@ -1,6 +1,8 @@
 ---
 # Enable Home Assistant API
-api: null
+api:
+  encryption:
+    key: !secret esphome_api_encryption_key
 
 captive_portal: null
 

--- a/config/smart-desk/esphome/smart-desk.yaml
+++ b/config/smart-desk/esphome/smart-desk.yaml
@@ -202,7 +202,7 @@ sensor:
   - id: smart_desk_height
     accuracy_decimals: 2
     lambda: |-
-      return id(ultrasonic_distance_sensor).state + ${desk_feet_height_m} + ${controller_box_height_m};
+      return id(ultrasonic_distance_sensor_filtered_delta).state + ${desk_feet_height_m} + ${controller_box_height_m};
     name: "Desk height"
     platform: template
     unit_of_measurement: m
@@ -211,13 +211,13 @@ sensor:
     accuracy_decimals: 2
     lambda: |-
       return id(ultrasonic_distance_sensor).state;
-    name: "Ultrasonic distance sensor (filtered, delta 0.01, throttle 0.5s)"
+    name: "Ultrasonic distance sensor (filtered)"
     platform: template
     unit_of_measurement: m
     update_interval: 5s
     filters:
       - delta: 0.01
-      - throttle: 0.5s
+      - throttle: 0.2s
 
 switch:
   - id: desk_relay_1

--- a/config/smart-desk/esphome/smart-desk.yaml
+++ b/config/smart-desk/esphome/smart-desk.yaml
@@ -69,12 +69,12 @@ logger:
     ultrasonic.sensor: INFO
 
 number:
-  - id: target_smart_desk_actuators_extension
+  - id: target_smart_desk_height
     platform: template
     icon: "mdi:icon7-resize-vertical"
-    name: "Desired actuators extension"
-    min_value: 0
-    max_value: ${max_actuators_extension_m}
+    name: "Desired desk height"
+    min_value: ${min_desk_height_m}
+    max_value: ${max_desk_height_m}
     optimistic: true
     step: 0.01
     unit_of_measurement: m
@@ -92,12 +92,12 @@ script:
       - if:
           condition:
             lambda: |-
-              return id(smart_desk_actuators_extension).state < id(target_smart_desk_actuators_extension).state;
+              return id(smart_desk_height).state < id(target_smart_desk_height).state;
           then:
-            - logger.log: "Current actuators extension < requested extension. Extending the actuators."
+            - logger.log: "Current desk height < requested height. Extending the actuators."
             - script.execute: extend_actuators_script
           else:
-            - logger.log: "Current actuators extension > requested extension. Retracting the actuators."
+            - logger.log: "Current desk height > requested height. Retracting the actuators."
             - script.execute: retract_actuators_script
   - id: extend_actuators_script
     then:
@@ -172,11 +172,11 @@ sensor:
             lambda: |-
               return id(extend_actuators).state || id(retract_actuators).state;
           then:
-            - logger.log: "The actuators are moving. Checking if the they reached the target extension..."
+            - logger.log: "The actuators are moving. Checking if the desk reached the target height..."
             - if:
                 condition:
                   lambda: |-
-                    float diff = id(smart_desk_actuators_extension).state - id(target_smart_desk_actuators_extension).state;
+                    float diff = id(smart_desk_height).state - id(target_smart_desk_height).state;
                     float abs_diff = abs(diff);
                     float distance_tolerance = ${distance_tolerance};
                     ESP_LOGD("main", "Difference: %f, Abs difference: %f, Tolerance: %f", diff, abs_diff, distance_tolerance);
@@ -188,10 +188,10 @@ sensor:
                       return false;
                     }
                 then:
-                  - logger.log: "The actuators reached the target extension. Stopping the actuators..."
+                  - logger.log: "The desk reached the target height. Stopping the actuators..."
                   - script.execute: turn_actuators_off_script
                 else:
-                  - logger.log: "The actuators didn't reach the target extension yet. Leaving the actuators on..."
+                  - logger.log: "The desk didn't reach the target height yet. Leaving the actuators on..."
           else:
             - logger.log:
                 format: "The actuators are not moving. Skipping the check."
@@ -199,21 +199,34 @@ sensor:
   - platform: wifi_signal
     name: "WiFi Signal Sensor"
     update_interval: 30s
-  - id: min_smart_desk_distance
-    platform: template
-    icon: "mdi:icon7-circle-arrow-down"
-    lambda: |-
-      return ${min_desk_distance_from_feet_m} - ${controller_box_height_m};
-    name: "Minimum distance between the bottom of the desk top and the distance sensor"
-    unit_of_measurement: m
-  - id: smart_desk_actuators_extension
+  - id: smart_desk_height
     accuracy_decimals: 2
     lambda: |-
-      return id(ultrasonic_distance_sensor).state - id(min_smart_desk_distance).state;
-    name: "Actuators extension"
+      return id(ultrasonic_distance_sensor).state + ${desk_feet_height_m} + ${controller_box_height_m};
+    name: "Desk height"
     platform: template
     unit_of_measurement: m
     update_interval: 5s
+  - id: ultrasonic_distance_sensor_filtered_quantile
+    accuracy_decimals: 2
+    lambda: |-
+      return id(ultrasonic_distance_sensor).state;
+    name: "Ultrasonic distance sensor (filtered, quantile)"
+    platform: template
+    unit_of_measurement: m
+    update_interval: 5s
+    filters:
+      - quantile: null
+  - id: ultrasonic_distance_sensor_filtered_delta
+    accuracy_decimals: 2
+    lambda: |-
+      return id(ultrasonic_distance_sensor).state;
+    name: "Ultrasonic distance sensor (filtered, delta 1)"
+    platform: template
+    unit_of_measurement: m
+    update_interval: 5s
+    filters:
+      - delta: 0.01
 
 switch:
   - id: desk_relay_1
@@ -285,13 +298,14 @@ substitutions:
   fqdn: ${device_name}.${network_domain}
   lcd_height: "4"
   lcd_width: "20"
-  distance_tolerance: "0.01"
-  # Maximum actuators extension
-  max_actuators_extension_m: "0.35"
-  # Minimum distance between the bottom of the desk top and the feet of the desk
-  min_desk_distance_from_feet_m: "0.67"
   # Height of the controller box + distance sensor heads when the distance sensor faces the bottom of the desk top
   controller_box_height_m: "0.165"
+  desk_feet_height_m: "0.04"
+  distance_tolerance: "0.01"
+  max_actuators_extension_m: "0.35"
+  # max_desk_height_m = ${min_desk_height_m} + ${max_actuators_extension_m}
+  max_desk_height_m: "1.085"
+  min_desk_height_m: "0.735"
   network_domain: edge.lab.ferrari.how
 
 text_sensor:

--- a/config/smart-desk/esphome/smart-desk.yaml
+++ b/config/smart-desk/esphome/smart-desk.yaml
@@ -50,9 +50,6 @@ esp32:
 
 esphome:
   name: smart-desk
-  on_boot:
-    then:
-      - switch.turn_on: smart_desk_automation_switch
 
 i2c:
   frequency: 100kHz
@@ -183,7 +180,7 @@ sensor:
       - if:
           condition:
             lambda: |-
-              return id(smart_desk_automation_switch).state && (id(extend_actuators).state || id(retract_actuators).state);
+              return id(extend_actuators).state || id(retract_actuators).state;
           then:
             - logger.log: "The actuators are moving. Checking if the they reached the target extension..."
             - if:
@@ -291,10 +288,6 @@ switch:
       - script.execute: retract_actuators_script
     turn_off_action:
       - script.execute: turn_actuators_off_script
-  - id: smart_desk_automation_switch
-    platform: template
-    name: "Smart desk automation. Disable to allow fine actuators extension tuning."
-    optimistic: true
 
 substitutions:
   device_name_upper: Smart Desk

--- a/config/smart-desk/esphome/smart-desk.yaml
+++ b/config/smart-desk/esphome/smart-desk.yaml
@@ -80,16 +80,6 @@ number:
     unit_of_measurement: m
     on_value:
       - script.execute: operate_actuators
-  - id: min_distance_offset
-    platform: template
-    icon: "mdi:icon7-resize-small"
-    name: "Offset to adjust the minimum distance between the bottom of the table top and the distance sensor"
-    min_value: 0
-    max_value: ${min_desk_distance_from_feet_m}
-    optimistic: true
-    restore_value: true
-    step: 0.01
-    unit_of_measurement: m
 
 ota:
   password: !secret esphome_ota_password
@@ -213,7 +203,7 @@ sensor:
     platform: template
     icon: "mdi:icon7-circle-arrow-down"
     lambda: |-
-      return ${min_desk_distance_from_feet_m} - (${controller_box_height_m} + id(min_distance_offset).state);
+      return ${min_desk_distance_from_feet_m} - ${controller_box_height_m};
     name: "Minimum distance between the bottom of the desk top and the distance sensor"
     unit_of_measurement: m
   - id: smart_desk_actuators_extension

--- a/config/smart-desk/esphome/smart-desk.yaml
+++ b/config/smart-desk/esphome/smart-desk.yaml
@@ -207,26 +207,17 @@ sensor:
     platform: template
     unit_of_measurement: m
     update_interval: 5s
-  - id: ultrasonic_distance_sensor_filtered_quantile
-    accuracy_decimals: 2
-    lambda: |-
-      return id(ultrasonic_distance_sensor).state;
-    name: "Ultrasonic distance sensor (filtered, quantile)"
-    platform: template
-    unit_of_measurement: m
-    update_interval: 5s
-    filters:
-      - quantile: null
   - id: ultrasonic_distance_sensor_filtered_delta
     accuracy_decimals: 2
     lambda: |-
       return id(ultrasonic_distance_sensor).state;
-    name: "Ultrasonic distance sensor (filtered, delta 1)"
+    name: "Ultrasonic distance sensor (filtered, delta 0.01, throttle 0.5s)"
     platform: template
     unit_of_measurement: m
     update_interval: 5s
     filters:
       - delta: 0.01
+      - throttle: 0.5s
 
 switch:
   - id: desk_relay_1

--- a/config/smart-desk/esphome/smart-desk.yaml
+++ b/config/smart-desk/esphome/smart-desk.yaml
@@ -162,13 +162,6 @@ sensor:
     unit_of_measurement: m
     update_interval: 500ms
     filters:
-      # Don't publish updates if the actuators are not moving
-      - lambda: |-
-          if (id(extend_actuators).state || id(retract_actuators).state) {
-            return x;
-          } else {
-            return {};
-          }
       # We know max and min allowed reads
       - lambda: |-
           if (x > 0.5 && x < 0.85) {
@@ -176,6 +169,9 @@ sensor:
           } else {
             return {};
           }
+      - median:
+          window_size: 3
+          send_every: 1
       - delta: 0.01
 
 switch:

--- a/config/smart-desk/esphome/smart-desk.yaml
+++ b/config/smart-desk/esphome/smart-desk.yaml
@@ -1,7 +1,8 @@
 ---
 # Enable Home Assistant API
 api:
-  password: !secret home_assistant_api_key
+  encryption:
+    key: !secret esphome_api_encryption_key
 
 captive_portal: null
 
@@ -94,7 +95,7 @@ number:
     unit_of_measurement: m
 
 ota:
-  password: !secret home_assistant_api_key
+  password: !secret esphome_ota_password
 
 prometheus: null
 

--- a/config/smart-desk/esphome/smart-desk.yaml
+++ b/config/smart-desk/esphome/smart-desk.yaml
@@ -106,7 +106,7 @@ script:
       - switch.turn_on: desk_relay_1
       - switch.turn_on: desk_relay_3
       # Turn the actuators off anyway as a safety measure
-      - delay: 1min
+      - delay: 90s
       - logger.log: "Safety timer expired. Stopping the actuators. Stopping the actuators in any case."
       - script.execute: turn_actuators_off_script
   - id: retract_actuators_script
@@ -116,7 +116,7 @@ script:
       - switch.turn_on: desk_relay_2
       - switch.turn_on: desk_relay_4
       # Turn the actuators off anyway as a safety measure
-      - delay: 1min
+      - delay: 90s
       - logger.log: "Safety timer expired. Stopping the actuators in any case."
       - script.execute: turn_actuators_off_script
   - id: turn_actuators_off_script

--- a/config/smart-desk/esphome/smart-desk.yaml
+++ b/config/smart-desk/esphome/smart-desk.yaml
@@ -68,37 +68,12 @@ logger:
     sensor: INFO
     ultrasonic.sensor: INFO
 
-number:
-  - id: target_smart_desk_height
-    platform: template
-    icon: "mdi:icon7-resize-vertical"
-    name: "Desired desk height"
-    min_value: ${min_desk_height_m}
-    max_value: ${max_desk_height_m}
-    optimistic: true
-    step: 0.01
-    unit_of_measurement: m
-    on_value:
-      - script.execute: operate_actuators
-
 ota:
   password: !secret esphome_ota_password
 
 prometheus: null
 
 script:
-  - id: operate_actuators
-    then:
-      - if:
-          condition:
-            lambda: |-
-              return id(smart_desk_height).state < id(target_smart_desk_height).state;
-          then:
-            - logger.log: "Current desk height < requested height. Extending the actuators."
-            - script.execute: extend_actuators_script
-          else:
-            - logger.log: "Current desk height > requested height. Retracting the actuators."
-            - script.execute: retract_actuators_script
   - id: extend_actuators_script
     then:
       - logger.log: "Extending the actuators..."
@@ -163,39 +138,10 @@ sensor:
     trigger_pin: GPIO27
     echo_pin: GPIO15
     name: "Ultrasonic distance sensor"
+    # Minimum recommended is 60ms (source: HC-SR04 datasheet)
     update_interval: 100ms
     # The number of meters for the sensor to timeout
     timeout: 4m
-    on_value:
-      - if:
-          condition:
-            lambda: |-
-              return id(extend_actuators).state || id(retract_actuators).state;
-          then:
-            - logger.log: "The actuators are moving. Checking if the desk reached the target height..."
-            - if:
-                condition:
-                  lambda: |-
-                    float diff = id(smart_desk_height).state - id(target_smart_desk_height).state;
-                    float abs_diff = abs(diff);
-                    float distance_tolerance = ${distance_tolerance};
-                    ESP_LOGD("main", "Difference: %f, Abs difference: %f, Tolerance: %f", diff, abs_diff, distance_tolerance);
-                    if (abs_diff < distance_tolerance){
-                      ESP_LOGD("main", "Abs difference is in the tolerance range. Condition matched.");
-                      return true;
-                    } else {
-                      ESP_LOGD("main", "Abs difference is not in the tolerance range. Condition not matched.");
-                      return false;
-                    }
-                then:
-                  - logger.log: "The desk reached the target height. Stopping the actuators..."
-                  - script.execute: turn_actuators_off_script
-                else:
-                  - logger.log: "The desk didn't reach the target height yet. Leaving the actuators on..."
-          else:
-            - logger.log:
-                format: "The actuators are not moving. Skipping the check."
-                level: VERBOSE
   - platform: wifi_signal
     name: "WiFi Signal Sensor"
     update_interval: 30s
@@ -206,7 +152,7 @@ sensor:
     name: "Desk height"
     platform: template
     unit_of_measurement: m
-    update_interval: 5s
+    update_interval: 500ms
   - id: ultrasonic_distance_sensor_filtered_delta
     accuracy_decimals: 2
     lambda: |-
@@ -214,10 +160,23 @@ sensor:
     name: "Ultrasonic distance sensor (filtered)"
     platform: template
     unit_of_measurement: m
-    update_interval: 5s
+    update_interval: 500ms
     filters:
+      # Don't publish updates if the actuators are not moving
+      - lambda: |-
+          if (id(extend_actuators).state || id(retract_actuators).state) {
+            return x;
+          } else {
+            return {};
+          }
+      # We know max and min allowed reads
+      - lambda: |-
+          if (x > 0.5 && x < 0.85) {
+            return x;
+          } else {
+            return {};
+          }
       - delta: 0.01
-      - throttle: 0.2s
 
 switch:
   - id: desk_relay_1
@@ -292,7 +251,6 @@ substitutions:
   # Height of the controller box + distance sensor heads when the distance sensor faces the bottom of the desk top
   controller_box_height_m: "0.165"
   desk_feet_height_m: "0.04"
-  distance_tolerance: "0.01"
   max_actuators_extension_m: "0.35"
   # max_desk_height_m = ${min_desk_height_m} + ${max_actuators_extension_m}
   max_desk_height_m: "1.085"


### PR DESCRIPTION
- Don't upload artifacts because they would be unusable in their current state anyway.
- Use the new `api.encryption.key` configuration directive.
- Remove the unfinished smart desk automation.
- Raise the actuators max operating time to 90 seconds to account for full extension and retraction.
- Add a template sensor to compute the height of the desktop.
- Add a template sensor to smooth the distance measurement.