### PR TITLE
Don't use branch to tag docker images

### DIFF
--- a/.github/workflows/build-container-images.yaml
+++ b/.github/workflows/build-container-images.yaml
@@ -38,12 +38,14 @@ jobs:
             org.opencontainers.image.title=home-lab-${{ matrix.container-image-context-directory }}
             org.opencontainers.image.description=${{ matrix.container-image-context-directory }} container image
           tags: |
+            type=edge,enable={{is_default_branch}}
             type=ref,event=branch,enable={{is_default_branch}}
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=sha
       - name: Build the ${{ matrix.container-image-context-directory }} container image
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/build-container-images.yaml
+++ b/.github/workflows/build-container-images.yaml
@@ -38,7 +38,7 @@ jobs:
             org.opencontainers.image.title=home-lab-${{ matrix.container-image-context-directory }}
             org.opencontainers.image.description=${{ matrix.container-image-context-directory }} container image
           tags: |
-            type=ref,event=branch
+            type=ref,event=branch,enable={{is_default_branch}}
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}.{{patch}}


### PR DESCRIPTION
Dependabot uses the relative path of the file to update as the branch name. This branch name is too long to be used as a container image tag, so we use it only for the default branch.