### PR TITLE
Enable periodic stationary object check

### DIFF
--- a/docker/ansible/etc/ansible/roles/ferrarimarco_home_lab_node/templates/frigate/config/config.yaml.jinja
+++ b/docker/ansible/etc/ansible/roles/ferrarimarco_home_lab_node/templates/frigate/config/config.yaml.jinja
@@ -3,6 +3,14 @@ mqtt:
   host: "{{ mosquitto_server_fqdn }}"
   port: 1883
 
+detect:
+  stationary:
+    # Frequency for confirming stationary objects
+    # When set to 0, object detection will not confirm stationary objects until movement is detected.
+    # If set to 10, object detection will run to confirm the object still exists on every 10th frame.
+    # Default is 0 (Frigate 0.12.0)
+    interval: 50
+
 detectors:
   coral:
     type: edgetpu


### PR DESCRIPTION
Sometimes Frigate is stuck with objects that exit the frame, so we enable stationary object re-check every few frames, and not just when motion is detected.