### PR TITLE
Check vars before use

### DIFF
--- a/config/ansible/roles/ferrarimarco_home_lab_node/templates/frigate/compose.yaml.jinja
+++ b/config/ansible/roles/ferrarimarco_home_lab_node/templates/frigate/compose.yaml.jinja
@@ -9,7 +9,7 @@ services:
     # Got those from
     devices:
       - /dev/bus/usb:/dev/bus/usb
-{% for device in frigate_gpu_decode_devices %}
+{% for device in frigate_gpu_decode_devices | default([]) %}
       - "{{ device }}:{{ device }}"
 {% endfor %}
     # We need host networking because Mosquitto listens on localhost only

--- a/config/ansible/roles/ferrarimarco_home_lab_node/templates/zigbee2mqtt/compose.yaml.jinja
+++ b/config/ansible/roles/ferrarimarco_home_lab_node/templates/zigbee2mqtt/compose.yaml.jinja
@@ -9,6 +9,8 @@ services:
       - /run/udev:/run/udev:ro
     ports:
       - {{ zigbee2mqtt_user_interface_host_port }}:8080
+{% if zigbee_adapter_device_path is defined %}
     devices:
       - "{{ zigbee_adapter_device_path }}:/dev/ttyACM0"
+{% endif %}
 ...


### PR DESCRIPTION
- Check that `frigate_gpu_decode_devices` exists before looping on it
- Check that `zigbee_adapter_device_path` is defined before using its value.