### PR TITLE
feat: group restic backups by host and tags

### DIFF
--- a/config/ansible/roles/ferrarimarco_home_lab_node/files/config/restic/entrypoint.sh
+++ b/config/ansible/roles/ferrarimarco_home_lab_node/files/config/restic/entrypoint.sh
@@ -27,13 +27,13 @@ restic list locks --no-lock --verbose
 if [ "${RESTIC_ENABLE_BACKUP:-"false"}" = "true" ]; then
   echo "Backing up ${RESTIC_DIRECTORIES_TO_BACKUP}. Tags: ${RESTIC_BACKUP_TAGS}"
   # Use eval here because restic interprets quotes literally
-  eval "restic backup --tag ${RESTIC_BACKUP_TAGS} --verbose ${RESTIC_DIRECTORIES_TO_BACKUP}"
+  eval "restic backup --group-by host,tags --tag ${RESTIC_BACKUP_TAGS} --verbose ${RESTIC_DIRECTORIES_TO_BACKUP}"
 fi
 
 if [ "${RESTIC_ENABLE_PRUNE:-"false"}" = "true" ]; then
   echo "Pruning ${RESTIC_REPOSITORY}"
   # Use eval here because restic interprets quotes literally
-  eval "restic forget --no-cache --prune --verbose ${RESTIC_FORGET_POLICY}"
+  eval "restic forget --group-by host,tags --no-cache --prune --verbose ${RESTIC_FORGET_POLICY}"
 fi
 
 if [ "${RESTIC_ENABLE_PRUNE_UNTAGGED_SNAPSHOTS:-"false"}" = "true" ]; then


### PR DESCRIPTION
Grouping backups by host and tags makes backups independent from the paths to backup.

The default grouping is host,paths.

Ref
https://restic.readthedocs.io/en/latest/040_backup.html#file-change-detection