### PR TITLE
fix: set git author email for renovate

### DIFF
--- a/.github/renovate-global-config.js
+++ b/.github/renovate-global-config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  gitAuthor: "41898282+github-actions[bot]@users.noreply.github.com",
   onboarding: false,
   platform: "github",
   repositories: ["ferrarimarco/home-lab"],


### PR DESCRIPTION
This should let Renovate correctly determine if a PR was modified or not, instead of assuming that it was modified.