### PR TITLE
ci: don't test playbooks on certain paths

### DIFF
--- a/.github/workflows/test-ansible.yaml
+++ b/.github/workflows/test-ansible.yaml
@@ -9,6 +9,11 @@ on: # yamllint disable-line rule:truthy
       - "docker/ansible/**"
       - "scripts/common.sh"
       - "scripts/run-ansible.sh"
+      # Don't test playbooks when editing these files because we have dedicated tests
+      - "!config/ansible/roles/ferrarimarco_home_lab_node/files/config/dependency-updates-helper/Dockerfile"
+      - "!config/ansible/roles/ferrarimarco_home_lab_node/files/config/monitoring-ont/requirements.txt"
+      - "!config/ansible/roles/ferrarimarco_home_lab_node/files/config/restic/Dockerfile"
+      - "!config/ansible/roles/ferrarimarco_home_lab_node/files/config/sense-hat-exporter/requirements.txt"
   pull_request:
     paths:
       - ".github/workflows/test-ansible.yaml"
@@ -16,6 +21,11 @@ on: # yamllint disable-line rule:truthy
       - "docker/ansible/**"
       - "scripts/common.sh"
       - "scripts/run-ansible.sh"
+      # Don't test playbooks when editing these files because we have dedicated tests
+      - "!config/ansible/roles/ferrarimarco_home_lab_node/files/config/dependency-updates-helper/Dockerfile"
+      - "!config/ansible/roles/ferrarimarco_home_lab_node/files/config/monitoring-ont/requirements.txt"
+      - "!config/ansible/roles/ferrarimarco_home_lab_node/files/config/restic/Dockerfile"
+      - "!config/ansible/roles/ferrarimarco_home_lab_node/files/config/sense-hat-exporter/requirements.txt"
 
 permissions:
   contents: read


### PR DESCRIPTION
Don't run time-consuming Ansible playbook tests when we already have tests in place.