### PR TITLE
fix: capture docker image digest in regex manager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,7 +44,7 @@
         "(^|/)*.sh"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:ENV|ARG)?\\s*.+?_VERSION=\"?(?<currentValue>.+?)\"?\\s"
+        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:ENV|ARG)?\\s*.+?_VERSION=\"?(?<currentValue>.+?)?(?:@(?<currentDigest>sha256:[a-f0-9]+))?\"?\\s"
       ]
     }
   ],


### PR DESCRIPTION
Capture the currentDigest group in the regex custom manager to support dependency pinning using hashes.

References:

- https://github.com/renovatebot/renovate/issues/24942
- https://github.com/renovatebot/renovate/issues/10993