### PR TITLE
fix: set autoReplaceStringTemplate for renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,6 +36,7 @@
   },
   "customManagers": [
     {
+      "autoReplaceStringTemplate": "{{{depName}}}:{{{newValue}}}@{{{newDigest}}}",
       "customType": "regex",
       "description": "Update _VERSION variables in Dockerfiles, and shell scripts",
       "fileMatch": [


### PR DESCRIPTION
Attempt to fix the issue with Renovate not able to pin digests with custom managers.

Ref: https://github.com/renovatebot/renovate/issues/10993