### PR TITLE
chore: disable pinning for regex manager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,7 +36,6 @@
   },
   "customManagers": [
     {
-      "autoReplaceStringTemplate": "{{{depName}}}:{{{newValue}}}@{{{newDigest}}}",
       "customType": "regex",
       "description": "Update _VERSION variables in Dockerfiles, and shell scripts",
       "fileMatch": [
@@ -46,7 +45,8 @@
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:ENV|ARG)?\\s*.+?_VERSION=\"?(?<currentValue>[a-z0-9.-]+)?(?:@(?<currentDigest>sha256:[a-f0-9]+))?\"?\\s"
-      ]
+      ],
+      "pinDigest": false
     }
   ],
   "rangeStrategy": "bump"


### PR DESCRIPTION
Disable dependency pinning for the regex customManager because it's not possible to write a suitable autoReplaceTemplate.